### PR TITLE
[FEATURE] 문제 리스트 조회 페이지 개발 (#8)

### DIFF
--- a/koco/src/components/layout/PageHeader/index.tsx
+++ b/koco/src/components/layout/PageHeader/index.tsx
@@ -1,0 +1,19 @@
+import backArrowIc from '@/assets/backArrowIc.svg';
+import { useNavigate } from 'react-router-dom';
+
+interface IPageHeaderProps {
+  title: string;
+}
+
+const PageHeader = ({ title }: IPageHeaderProps) => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex gap-6 mb-10  px-4 py-6">
+      <img src={backArrowIc} onClick={() => navigate(-1)} />
+      <h1 className="text-xl mb-4">{title}</h1>
+    </div>
+  );
+};
+
+export default PageHeader;

--- a/koco/src/pages/ProblemListPage/components/Calendar/index.tsx
+++ b/koco/src/pages/ProblemListPage/components/Calendar/index.tsx
@@ -1,0 +1,11 @@
+const Calendar = () => {
+  const todayDate = new Date().toISOString().split('T')[0];
+
+  return (
+    <div className="p-4">
+      <input type="date" defaultValue={todayDate} />
+    </div>
+  );
+};
+
+export default Calendar;

--- a/koco/src/pages/ProblemListPage/components/ProblemItem/index.tsx
+++ b/koco/src/pages/ProblemListPage/components/ProblemItem/index.tsx
@@ -1,0 +1,33 @@
+import { useNavigate } from 'react-router-dom';
+
+interface IProblemItemProps {
+  problemId: number;
+  title: string;
+  tier: string;
+}
+
+const ProblemItem = ({ problemId, title, tier }: IProblemItemProps) => {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate(`/problems/${problemId}`);
+  };
+
+  return (
+    <div
+      onClick={handleClick}
+      className="flex items-center justify-between cursor-pointer p-4 hover:bg-gray-100 rounded-md"
+    >
+      <div className="flex items-center gap-2">
+        <div className="bg-[#A0522D] text-white text-xs px-2 py-1 rounded-md font-bold">{tier}</div>
+        <div className="flex flex-col">
+          <span className="font-bold text-sm">#{problemId}번</span>
+          <span className="text-sm">{title}</span>
+        </div>
+      </div>
+      <span className="text-gray-400 text-xl">{'>'}</span>
+    </div>
+  );
+};
+
+export default ProblemItem;

--- a/koco/src/pages/ProblemListPage/index.tsx
+++ b/koco/src/pages/ProblemListPage/index.tsx
@@ -1,0 +1,7 @@
+import PageHeader from '@/components/layout/PageHeader';
+
+const ProblemListPage = () => {
+  return <PageHeader title="문제 해설" />;
+};
+
+export default ProblemListPage;

--- a/koco/src/pages/ProblemListPage/index.tsx
+++ b/koco/src/pages/ProblemListPage/index.tsx
@@ -1,7 +1,23 @@
 import PageHeader from '@/components/layout/PageHeader';
+import Calendar from './components/Calendar';
+import ProblemItem from './components/ProblemItem';
+import MOCK_PROBLEM_DATA from '@/temp/mock/dateProblem.json';
 
 const ProblemListPage = () => {
-  return <PageHeader title="문제 해설" />;
+  return (
+    <div className="bg-background min-h-screen">
+      <PageHeader title="문제 해설" />
+      <Calendar />
+      {MOCK_PROBLEM_DATA.problems.map(problem => (
+        <ProblemItem
+          key={problem.problemId}
+          problemId={problem.problemId}
+          title={problem.tier}
+          tier={problem.tier}
+        />
+      ))}
+    </div>
+  );
 };
 
 export default ProblemListPage;

--- a/koco/src/pages/SurveyPage/index.tsx
+++ b/koco/src/pages/SurveyPage/index.tsx
@@ -3,8 +3,8 @@ import React, { useEffect, useState } from 'react';
 import QuestionCard from './components/QuestionCard';
 import MOCK_DATA from '@/temp/mock/dateProblem.json';
 import Button from '@/components/ui/Button';
-import backArrowIc from '@/assets/backArrowIc.svg';
 import { useNavigate } from 'react-router-dom';
+import PageHeader from '@/components/layout/PageHeader';
 //import { useGetProblemList } from '@/hooks/useGetProblemList';
 
 interface ISurveyData {
@@ -64,12 +64,8 @@ const SurveyPage = () => {
   }, [problems]);
 
   return (
-    <div className="bg-background min-h-screen px-4 py-6">
-      <div className="flex gap-6 mb-10">
-        <img src={backArrowIc} onClick={() => navigate(-1)} />
-        <h1 className="text-xl mb-4">문제 해설</h1>
-      </div>
-
+    <div className="bg-background min-h-screen">
+      <PageHeader title="설문" />
       {problems.map((problem: Problem) => (
         <QuestionCard
           key={problem.problemId}

--- a/koco/src/routes/RootRoutes.tsx
+++ b/koco/src/routes/RootRoutes.tsx
@@ -4,6 +4,7 @@ import LoginPage from '@/pages/Login';
 import FirstLoginPage from '@/pages/FirstLoginPage';
 import MainPage from '@/pages/MainPage';
 import SurveyPage from '@/pages/SurveyPage';
+import ProblemListPage from '@/pages/ProblemListPage';
 
 const RootRoutes = () => {
   return (
@@ -14,6 +15,7 @@ const RootRoutes = () => {
           <Route path="/complete-profile" element={<FirstLoginPage />} />
           <Route path="/home" element={<MainPage />} />
           <Route path="/survey" element={<SurveyPage />} />
+          <Route path="/problems" element={<ProblemListPage />} />
         </Route>
       </Routes>
     </BrowserRouter>


### PR DESCRIPTION
# TITLE
[FEATURE] 문제 리스트 조회 페이지 개발 (#8)

## 📝 개요
날짜에 따라 문제 리스트를 조회할 수 있는 페이지를 개발합니다.

## 🔗 연관된 이슈
- #8 

## 🔄 변경사항 및 이유
다른 페이지에서 재사용하기 위해 뒤로가기 버튼과 타이틀이 있는 헤더를 공통 컴포넌트로 분리하였습니다.

## 📋 작업할 내용
- [x] Calendar 컴포넌트 구현
- [x] ProblemItem 컴포넌트 구현

## 🔖 기타사항

## 👀 리뷰 요구사항 

## 🔗 참고 자료 (선택)

