### PR TITLE
[FEATURE] 메인 페이지 - 레이더 차트 개발 (#14)

### DIFF
--- a/koco/package-lock.json
+++ b/koco/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.4",
+        "chart.js": "^4.4.9",
         "react": "^19.0.0",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.5.2",
         "tailwindcss": "^4.1.4"
@@ -853,6 +855,11 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2047,6 +2054,17 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.9.tgz",
+      "integrity": "sha512-EyZ9wWKgpAU0fLJ43YAEIF8sr5F2W3LqbS40ZJyHIner2lY14ufqv2VMp69MAiZ2rpwxEUxEhIH/0U3xyRynxg==",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/color-convert": {
@@ -4477,6 +4495,15 @@
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/koco/package.json
+++ b/koco/package.json
@@ -11,7 +11,9 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.4",
+    "chart.js": "^4.4.9",
     "react": "^19.0.0",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.5.2",
     "tailwindcss": "^4.1.4"

--- a/koco/src/pages/MainPage/components/ContinuousCard/index.tsx
+++ b/koco/src/pages/MainPage/components/ContinuousCard/index.tsx
@@ -1,13 +1,17 @@
 import Card from '@/components/ui/Card';
 import ContinuousIc from '@/assets/continuousIc.svg';
 
-const ContinuousDayCard = () => (
+interface IContinuousDayCard {
+  continuousAttendance: number;
+}
+
+const ContinuousDayCard = ({ continuousAttendance }: IContinuousDayCard) => (
   <Card className="p-4 flex items-center justify-around">
     <div className="flex items-center gap-2">
       <img src={ContinuousIc} />
       <p className="text-regular-14 text-text-secondary">연속 학습일</p>
     </div>
-    <p className="text-bold-16 text-text-primary">3일</p>
+    <p className="text-bold-16 text-text-primary">{continuousAttendance}일</p>
   </Card>
 );
 

--- a/koco/src/pages/MainPage/components/ProfileCard/index.tsx
+++ b/koco/src/pages/MainPage/components/ProfileCard/index.tsx
@@ -1,9 +1,14 @@
 import Button from '@/components/ui/Button';
 import Card from '@/components/ui/Card';
 import { useNavigate } from 'react-router-dom';
-import DEFAULT_IMG from '@/assets/defaultProfileImage.svg';
 
-const ProfileCard = () => {
+interface IProfileCardProps {
+  profileImgUrl: string;
+  nickname: string;
+  statusMessage: string;
+}
+
+const ProfileCard = ({ profileImgUrl, nickname, statusMessage }: IProfileCardProps) => {
   const navigate = useNavigate();
 
   return (
@@ -11,13 +16,13 @@ const ProfileCard = () => {
       <div className="flex flex-col gap-2">
         <div className="flex gap-8">
           <img
-            src={DEFAULT_IMG}
-            alt="profile"
+            src={profileImgUrl}
+            alt=""
             className="w-20 h-20 rounded-full object-cover bg-[#EFEFEF]"
           />
           <div className="flex flex-col justify-center gap-2">
-            <p className="text-bold-14">홍길동</p>
-            <p className=" text-text-secondary text-regular-14">“상태 메시지”</p>
+            <p className="text-bold-14">{nickname}</p>
+            <p className=" text-text-secondary text-regular-14">{statusMessage}</p>
           </div>
         </div>
 

--- a/koco/src/pages/MainPage/components/TotalStudyCard/components/RadarChart/index.tsx
+++ b/koco/src/pages/MainPage/components/TotalStudyCard/components/RadarChart/index.tsx
@@ -1,0 +1,71 @@
+import {
+  Chart as ChartJS,
+  RadialLinearScale,
+  PointElement,
+  LineElement,
+  Filler,
+  Tooltip,
+  Legend,
+  ChartOptions,
+  ChartData,
+} from 'chart.js';
+import { Radar } from 'react-chartjs-2';
+
+ChartJS.register(RadialLinearScale, PointElement, LineElement, Filler, Tooltip, Legend);
+
+interface IStudyStat {
+  categoryId: number;
+  categoryName: string;
+  correctRate: number;
+}
+
+interface ITotalStudyCardProps {
+  studyStats: IStudyStat[];
+}
+
+const RadarChart = ({ studyStats }: ITotalStudyCardProps) => {
+  const data: ChartData<'radar'> = {
+    labels: studyStats.map(stat => stat.categoryName),
+    datasets: [
+      {
+        label: '정답률 (%)',
+        data: studyStats.map(stat => stat.correctRate),
+        backgroundColor: 'rgba(59, 130, 246, 0.4)',
+        borderColor: '#3B82F6',
+        borderWidth: 2,
+        pointRadius: 3,
+      },
+    ],
+  };
+
+  const options: ChartOptions<'radar'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      r: {
+        suggestedMin: 0,
+        suggestedMax: 100,
+        ticks: {
+          display: false,
+          stepSize: 20,
+          color: '#9CA3AF',
+        },
+        angleLines: { color: '#E5E7EB' },
+        grid: { color: '#E5E7EB' },
+        pointLabels: { color: '#4B5563' },
+      },
+    },
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        callbacks: {
+          label: ctx => `${ctx.label}: ${ctx.parsed.r}%`,
+        },
+      },
+    },
+  };
+
+  return <Radar data={data} options={options} />;
+};
+
+export default RadarChart;

--- a/koco/src/pages/MainPage/components/TotalStudyCard/index.tsx
+++ b/koco/src/pages/MainPage/components/TotalStudyCard/index.tsx
@@ -1,10 +1,21 @@
 import Card from '@/components/ui/Card';
+import RadarChart from './components/RadarChart';
 
-const TotalStudyCard = () => (
+interface IStudyStat {
+  categoryId: number;
+  categoryName: string;
+  correctRate: number;
+}
+
+interface ITotalStudyCardProps {
+  studyStats: IStudyStat[];
+}
+
+const TotalStudyCard = ({ studyStats }: ITotalStudyCardProps) => (
   <Card className="p-4 flex justify-between">
-    <p className="text-text-primary text-bold-16">나의 공부량</p>
-    <div className="w-80 h-40 bg-border rounded-md flex items-center justify-center text-xs text-text-disabled">
-      차트 ..
+    <p className="text-text-primary text-md">나의 공부량</p>
+    <div className="w-100 h-60 rounded-md flex items-center justify-center text-xs text-text-disabled">
+      <RadarChart studyStats={studyStats} />
     </div>
   </Card>
 );

--- a/koco/src/pages/MainPage/index.tsx
+++ b/koco/src/pages/MainPage/index.tsx
@@ -4,14 +4,22 @@ import GameBannerCard from './components/GameBannerCard';
 import ProfileCard from './components/ProfileCard';
 import TotalStudyCard from './components/TotalStudyCard';
 import Header from '@/components/layout/Header';
+import MOCK_DASHBOARD_DATA from '@/temp/mock/dashboard.json';
 
 const MainPage = () => {
+  const { studyStats, profileImgUrl, nickname, statusMessage, continuousAttendance } =
+    MOCK_DASHBOARD_DATA;
+
   return (
     <div className="flex flex-col gap-6 p-6 pb-30">
       <Header />
-      <ProfileCard />
-      <ContinuousDayCard />
-      <TotalStudyCard />
+      <ProfileCard
+        profileImgUrl={profileImgUrl}
+        nickname={nickname}
+        statusMessage={statusMessage}
+      />
+      <ContinuousDayCard continuousAttendance={continuousAttendance} />
+      <TotalStudyCard studyStats={studyStats} />
       <GameBannerCard />
       <BottomNav />
     </div>

--- a/koco/src/pages/ProblemListPage/index.tsx
+++ b/koco/src/pages/ProblemListPage/index.tsx
@@ -8,6 +8,7 @@ const ProblemListPage = () => {
     <div className="bg-background min-h-screen">
       <PageHeader title="문제 해설" />
       <Calendar />
+      <hr className="border-border" />
       {MOCK_PROBLEM_DATA.problems.map(problem => (
         <ProblemItem
           key={problem.problemId}

--- a/koco/src/temp/mock/dashboard.json
+++ b/koco/src/temp/mock/dashboard.json
@@ -1,0 +1,35 @@
+{
+  "userId": 1,
+  "nickname": "지연우",
+  "statusMessage": "솔브닥 스트릭 100일 채우자",
+  "profileImgUrl": "../../../assets/defaultProfileImage.png",
+  "todayProblemSetId": 32,
+  "continuousAttendance": 5,
+  "studyStats": [
+    {
+      "categoryId": 1,
+      "categoryName": "DP",
+      "correctRate": 92.5
+    },
+    {
+      "categoryId": 3,
+      "categoryName": "구현",
+      "correctRate": 87.0
+    },
+    {
+      "categoryId": 2,
+      "categoryName": "그래프",
+      "correctRate": 84.2
+    },
+    {
+      "categoryId": 5,
+      "categoryName": "탐색",
+      "correctRate": 80.6
+    },
+    {
+      "categoryId": 4,
+      "categoryName": "정렬",
+      "correctRate": 79.9
+    }
+  ]
+}


### PR DESCRIPTION
# TITLE
[FEATURE] 메인 페이지 - 레이더 차트 개발

## 📝 개요

chart.js, react-chartjs-2 사용하여 레이더 차트를 구현하였습니다.

## 🔗 연관된 이슈
- close #14 

## 🔄 변경사항 및 이유
사용자 메인페이지에서 mock data를 기반으로 데이터를 연결하였습니다.

## 📋 작업 내용
- [x] 메인페이지 mock data 연결
- [x] 레이더 차트 개발
- [x] 레이더 차트 반응형으로 구현 

## 🔖 기타사항
- chart.js, react-chartjs-2 는 추후 도넛, 막대 그래프 등 다른 통계 페이지를 구현하기 위해서 사용할 예정입니다.

## 👀 리뷰 요구사항 (선택)

## 🔗 참고 자료 (선택)

