### PR TITLE
[CHORE] API 연결 수정 (#21)

### DIFF
--- a/koco/src/apis/authApi.ts
+++ b/koco/src/apis/authApi.ts
@@ -14,7 +14,7 @@ const refreshAxios = axios.create({
  */
 export const loginWithKakao = async (code: string) => {
   const response = await axios.get<
-    IApiResponse<{ email: string; name: string; registered: boolean }>
+    IApiResponse<{ email: string; name: string; isRegistered: boolean }>
   >(`/api/v1/auth/callback?code=${code}`);
 
   return response.data.data;

--- a/koco/src/apis/authApi.ts
+++ b/koco/src/apis/authApi.ts
@@ -13,8 +13,8 @@ const refreshAxios = axios.create({
  * @param code
  */
 export const loginWithKakao = async (code: string) => {
-  const response = await axios.post<
-    IApiResponse<{ email: string; name: string; isRegistered: boolean }>
+  const response = await axios.get<
+    IApiResponse<{ email: string; name: string; registered: boolean }>
   >(`/api/v1/auth/callback?code=${code}`);
 
   return response.data.data;

--- a/koco/src/apis/axios/index.ts
+++ b/koco/src/apis/axios/index.ts
@@ -4,9 +4,9 @@ const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080',
   timeout: 10000, // 10초로 증가
   withCredentials: true,
-  headers: {
-    'Content-Type': 'application/json',
-  },
+  // headers: {
+  //   'Content-Type': 'application/json',
+  // },
 });
 
 // 토큰 갱신 전용 axios 인스턴스
@@ -32,7 +32,11 @@ const refreshToken = async () => {
 // 요청 인터셉터 - 로깅 및 요청 전 추가 처리
 axiosInstance.interceptors.request.use(
   config => {
-    // 요청 전 로깅 또는 추가 헤더 설정 가능
+    // 파일을 포함한 요청인 경우 자동으로 'Content-Type'을 설정하지 않음
+    if (config.data instanceof FormData) {
+      // FormData는 axios가 자동으로 처리하도록 설정
+      delete config.headers['Content-Type']; // 'Content-Type' 헤더를 제거
+    }
     console.log(`[Request] ${config.method?.toUpperCase()} ${config.url}`);
 
     return config;

--- a/koco/src/apis/axios/index.ts
+++ b/koco/src/apis/axios/index.ts
@@ -1,43 +1,19 @@
-// src/apis/axios.ts
-import axios, { AxiosError, InternalAxiosRequestConfig } from 'axios';
+import axios from 'axios';
 
-// Create a base axios instance
 const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080',
-  timeout: 10000,
-  withCredentials: true, // HttpOnly 쿠키 전송을 위해 필요
+  timeout: 10000, // 10초로 증가
+  withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
   },
 });
 
-// 토큰 갱신 중인지 확인하는 플래그
-let isRefreshing = false;
-// 요청 큐 저장
-let failedQueue: {
-  resolve: (value: unknown) => void;
-  reject: (reason?: unknown) => void;
-  config: InternalAxiosRequestConfig;
-}[] = [];
-
-// 요청 큐 처리 함수
-const processQueue = (error: AxiosError | null, token: string | null = null) => {
-  failedQueue.forEach(prom => {
-    if (error) {
-      prom.reject(error);
-    } else {
-      console.log(token);
-      prom.resolve(axiosInstance(prom.config));
-    }
-  });
-
-  failedQueue = [];
-};
-
 // 토큰 갱신 전용 axios 인스턴스
 const refreshAxios = axios.create({
   baseURL: axiosInstance.defaults.baseURL,
   withCredentials: true,
+  timeout: 5000, // 토큰 갱신은 좀 더 짧게
 });
 
 // 토큰 갱신 함수
@@ -46,74 +22,67 @@ const refreshToken = async () => {
     const response = await refreshAxios.post('/api/v1/auth/refresh');
 
     return response.status === 200;
-  } catch {
+  } catch (error) {
+    console.error('토큰 갱신 실패:', error);
+
     return false;
   }
 };
 
-// 요청 인터셉터
+// 요청 인터셉터 - 로깅 및 요청 전 추가 처리
 axiosInstance.interceptors.request.use(
   config => {
+    // 요청 전 로깅 또는 추가 헤더 설정 가능
+    console.log(`[Request] ${config.method?.toUpperCase()} ${config.url}`);
+
     return config;
   },
-  error => {
-    return Promise.reject(error);
-  }
+  error => Promise.reject(error)
 );
 
 // 응답 인터셉터
 axiosInstance.interceptors.response.use(
-  response => {
-    return response;
-  },
+  response => response,
   async error => {
     const originalRequest = error.config;
 
-    // 401 에러이고 재시도하지 않은 요청인 경우
+    // 401 (인증 실패) 처리
     if (error.response?.status === 401 && !originalRequest._retry) {
-      if (isRefreshing) {
-        // 이미 토큰 갱신 중이면 요청을 큐에 추가
-        return new Promise((resolve, reject) => {
-          failedQueue.push({
-            resolve,
-            reject,
-            config: originalRequest,
-          });
-        });
-      }
-
       originalRequest._retry = true;
-      isRefreshing = true;
 
       try {
-        // 토큰 갱신 시도
         const success = await refreshToken();
 
         if (success) {
-          // 성공하면 큐 처리하고 원래 요청 재시도
-          processQueue(null);
-          isRefreshing = false;
-
-          // HttpOnly 쿠키이므로 헤더 수정 불필요
           return axiosInstance(originalRequest);
         } else {
-          // 실패하면 로그인 페이지로 리다이렉트
-          processQueue(error);
-          isRefreshing = false;
+          // 토큰 갱신 실패 시 로그인 페이지로
           window.location.href = '/';
 
           return Promise.reject(error);
         }
       } catch (refreshError) {
-        processQueue(refreshError as AxiosError);
-        isRefreshing = false;
         window.location.href = '/';
 
         return Promise.reject(refreshError);
       }
     }
 
-    // 다른 에러 처리
+    // 500 에러 처리 - 서버 에러 로깅 및 사용자 알림
+    if (error.response?.status === 500) {
+      console.error('서버 내부 에러:', error.response.data);
+
+      return Promise.reject(error);
+    }
+
+    // 네트워크 에러 처리
+    if (error.message === 'Network Error') {
+      alert('네트워크 연결을 확인해주세요.');
+
+      return Promise.reject(error);
+    }
+
+    // 기타 에러 처리
     return Promise.reject(error);
   }
 );

--- a/koco/src/apis/problemApi.ts
+++ b/koco/src/apis/problemApi.ts
@@ -65,5 +65,7 @@ export const getProblemSolution = async (problemNumber: number) => {
     `${V1_SUB_URL}/${problemNumber}/solution`
   );
 
-  return response.data.data;
+  console.log(response.data.data);
+
+  return response?.data?.data;
 };

--- a/koco/src/apis/userApi.ts
+++ b/koco/src/apis/userApi.ts
@@ -36,9 +36,10 @@ export const completeProfile = async ({
  */
 
 export const getUserDashboard = async (date: string) => {
-  const response = await axios.post<IApiResponse<IGetUserDashboardResponse>>(
+  const response = await axios.get<IApiResponse<IGetUserDashboardResponse>>(
     `${V1_SUB_URL}/dashboard?date=${date}`
   );
+  console.log(response.data);
 
   return response.data.data;
 };

--- a/koco/src/apis/userApi.ts
+++ b/koco/src/apis/userApi.ts
@@ -7,24 +7,20 @@ const V1_SUB_URL = '/api/v1/users';
 
 /**
  * POST) 사용자 추가 정보 등록
- * @request_body nickname, profileImgUrl, statusMsg
+ * @request_body nickname, profileImg, statusMsg
  */
 
 export interface ICompleteProfileRequest {
   nickname: string;
-  profileImgUrl: string;
+  profileImg: string;
   statusMsg: string;
 }
 
-export const completeProfile = async ({
-  nickname,
-  profileImgUrl,
-  statusMsg,
-}: ICompleteProfileRequest) => {
-  const response = await axios.post<IApiResponse<null>>(`${V1_SUB_URL}/me`, {
-    nickname,
-    profileImgUrl,
-    statusMsg,
+export const completeProfile = async (formData: FormData) => {
+  const response = await axios.post<IApiResponse<null>>(`${V1_SUB_URL}/me`, formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
   });
 
   return response.data.data;

--- a/koco/src/components/layout/BottomNav/index.tsx
+++ b/koco/src/components/layout/BottomNav/index.tsx
@@ -10,7 +10,7 @@ const BottomNav = () => {
       <nav className="w-full max-w-xl bg-white shadow-[0_-2px_4px_rgba(0,0,0,0.06)] flex justify-around items-center py-2 px-6 rounded-t-xl">
         <div className="group flex flex-col items-center text-xs text-text- gap-1 hover:text-primary-hover transition-colors duration-200">
           <img
-            onClick={() => navigate('/survey')}
+            onClick={() => navigate('/problems')}
             src={solutionIc}
             width={18}
             height={18}

--- a/koco/src/hooks/mutations/useAuthMutations.ts
+++ b/koco/src/hooks/mutations/useAuthMutations.ts
@@ -12,7 +12,8 @@ export const useKakaoLogin = () => {
   return useMutation({
     mutationFn: (code: string) => loginWithKakao(code),
     onSuccess: response => {
-      if (response.registered === false) {
+      console.log(response);
+      if (response.isRegistered === false) {
         navigate('/complete-profile');
       } else {
         navigate('/home');

--- a/koco/src/hooks/mutations/useAuthMutations.ts
+++ b/koco/src/hooks/mutations/useAuthMutations.ts
@@ -12,15 +12,11 @@ export const useKakaoLogin = () => {
   return useMutation({
     mutationFn: (code: string) => loginWithKakao(code),
     onSuccess: response => {
-      if (response.isRegistered === false) {
+      if (response.registered === false) {
         navigate('/complete-profile');
       } else {
         navigate('/home');
       }
-    },
-    onError: () => {
-      console.log('로그인 실패, 홈 이동 (개발모드)');
-      navigate('/home');
     },
   });
 };

--- a/koco/src/hooks/mutations/useProblemMutations.ts
+++ b/koco/src/hooks/mutations/useProblemMutations.ts
@@ -14,6 +14,7 @@ export const useRegisterSurvey = () => {
     mutationFn: (data: IProblemSurveyRequest) => registerSurvey(data),
     onSuccess: () => {
       // 성공 시 관련 쿼리 무효
+
       const today = new Date().toISOString().split('T')[0];
       queryClient.invalidateQueries({ queryKey: queryKeys.problems.set(today) });
       queryClient.invalidateQueries({ queryKey: queryKeys.users.dashboard(today) });

--- a/koco/src/hooks/mutations/useUserMutations.ts
+++ b/koco/src/hooks/mutations/useUserMutations.ts
@@ -1,6 +1,6 @@
 // src/hooks/mutations/useUserMutations.ts
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { completeProfile, deleteUser, ICompleteProfileRequest } from '@/apis/userApi';
+import { completeProfile, deleteUser } from '@/apis/userApi';
 
 /**
  * 사용자 프로필 완성 뮤테이션 훅
@@ -9,10 +9,10 @@ export const useCompleteProfile = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: ICompleteProfileRequest) => completeProfile(data),
+    mutationFn: (data: FormData) => completeProfile(data),
     onSuccess: () => {
       // 성공 시 관련 쿼리 무효화
-      queryClient.invalidateQueries({ queryKey: ['userDashboard'] });
+      queryClient.invalidateQueries({ queryKey: ['complete-profile'] });
     },
   });
 };
@@ -27,7 +27,7 @@ export const useDeleteUser = () => {
     mutationFn: deleteUser,
     onSuccess: () => {
       // 성공 시 모든 사용자 관련 쿼리 무효화
-      queryClient.invalidateQueries({ queryKey: ['userDashboard'] });
+      queryClient.invalidateQueries({ queryKey: ['delete-user'] });
     },
   });
 };

--- a/koco/src/hooks/queries/useProblemQueries.ts
+++ b/koco/src/hooks/queries/useProblemQueries.ts
@@ -2,9 +2,9 @@
 import { useQuery } from '@tanstack/react-query';
 import { getProblem, getProblemSolution, IGetProblemSolutionResponse } from '@/apis/problemApi';
 import { queryKeys } from './queryKeys';
-import MOCK_PROBLEM_DATA from '@/temp/mock/dateProblem';
+//import MOCK_PROBLEM_DATA from '@/temp/mock/dateProblem';
 import { IGetProblemSetResponse } from '@/@types/problem';
-import MOCK_SOLUTION_DATA from '@/temp/mock/solution';
+//import MOCK_SOLUTION_DATA from '@/temp/mock/solution';
 /**
  * 특정 날짜의 문제 세트를 조회하는 훅
  * @param date YYYY-MM-DD 형식의 날짜
@@ -13,7 +13,7 @@ export const useProblemSet = (date: string) => {
   return useQuery<IGetProblemSetResponse>({
     queryKey: queryKeys.problems.set(date),
     queryFn: () => getProblem(date),
-    initialData: MOCK_PROBLEM_DATA,
+    //initialData: MOCK_PROBLEM_DATA,
     enabled: !!date, // 날짜가 있을 때만 쿼리 활성화
   });
 };
@@ -26,7 +26,7 @@ export const useProblemSolution = (problemNumber: number) => {
   return useQuery<IGetProblemSolutionResponse>({
     queryKey: queryKeys.problems.solution(problemNumber),
     queryFn: () => getProblemSolution(problemNumber),
-    initialData: MOCK_SOLUTION_DATA,
+    //initialData: MOCK_SOLUTION_DATA,
     enabled: !!problemNumber, // 문제 번호가 있을 때만 쿼리 활성화
     staleTime: 1000 * 60 * 60, // 1시간 (해설은 자주 변경되지 않음)
   });

--- a/koco/src/pages/FirstLoginPage/index.tsx
+++ b/koco/src/pages/FirstLoginPage/index.tsx
@@ -4,16 +4,17 @@ import DEFAULT_IMG from '@/assets/defaultProfileImage.svg';
 import useInput from '@/hooks/custom/useInput';
 import useFileInput from '@/hooks/custom/useFileInput';
 import Button from '@/components/ui/Button';
+import { useCompleteProfile } from '@/hooks/mutations/useUserMutations';
 
 export default function FirstLoginPage() {
   const fileRef = useRef<HTMLInputElement | null>(null);
   const navigate = useNavigate();
 
   const { value: nickname, onChange: onChangeNickname } = useInput();
-  const { value: statusMessage, onChange: onChangeStatusMessage } = useInput();
+  const { value: statusMsg, onChange: onChangeStatusMessage } = useInput();
   const { preview, onChange: onChangeFile } = useFileInput();
 
-  //const completeProfileMutation = useCompleteProfile();
+  const completeProfileMutation = useCompleteProfile();
 
   /* 유효성 검사 로직 */
   const nicknameErr = useMemo(() => {
@@ -25,8 +26,7 @@ export default function FirstLoginPage() {
     return null;
   }, [nickname]);
 
-  const statusErr =
-    statusMessage.length > 50 ? '상태메세지는 최대 50자까지 작성 가능합니다.' : null;
+  const statusErr = statusMsg.length > 50 ? '상태메세지는 최대 50자까지 작성 가능합니다.' : null;
 
   const canSubmit = !nicknameErr && !statusErr && nickname;
 
@@ -34,13 +34,25 @@ export default function FirstLoginPage() {
   const handleSubmit = () => {
     if (!canSubmit) return;
 
-    // const form = new FormData();
-    // if (file) form.append('profile', file);
-    // form.append('nickname', nickname);
-    // form.append('status', status);
+    const formData = new FormData();
 
-    // completeProfileMutation(form);
-    navigate('/home');
+    if (fileRef.current?.files?.[0]) {
+      formData.append('profileImg', fileRef.current.files[0]);
+    }
+
+    if (nickname) {
+      formData.append('nickname', nickname);
+    }
+
+    if (statusMsg) {
+      formData.append('statusMsg', statusMsg);
+    }
+
+    completeProfileMutation.mutate(formData, {
+      onSuccess: () => {
+        navigate('/home');
+      },
+    });
   };
 
   return (
@@ -84,7 +96,7 @@ export default function FirstLoginPage() {
       {/* 상태메시지 */}
       <label className="mt-4 mb-4 w-full max-w-md text-bold-14">상태 메시지 (선택)</label>
       <input
-        value={statusMessage}
+        value={statusMsg}
         onChange={onChangeStatusMessage}
         placeholder="상태메세지를 작성해주세요"
         className="bg-input w-full max-w-md rounded-lg py-3 px-4 outline-none text-sm "

--- a/koco/src/pages/KakaoCallbackPage/index.tsx
+++ b/koco/src/pages/KakaoCallbackPage/index.tsx
@@ -5,18 +5,18 @@ import { useKakaoLogin } from '@/hooks/mutations/useAuthMutations';
 
 const KakaoCallback = () => {
   const location = useLocation();
-  const kakaoLoginMutation = useKakaoLogin();
+  const { mutate, isSuccess, isError } = useKakaoLogin();
 
   useEffect(() => {
     // URL에서 인가 코드 추출
     const params = new URLSearchParams(location.search);
     const code = params.get('code');
+    //const navigate = useNavigate();
 
-    if (code) {
-      // 인가 코드로 로그인 처리
-      kakaoLoginMutation.mutate(code);
+    if (code && !isSuccess && !isError) {
+      mutate(code);
     }
-  }, [location, kakaoLoginMutation]);
+  }, [location, mutate]);
 
   // 로딩 UI
   return (

--- a/koco/src/pages/ProblemListPage/components/ProblemItem/index.tsx
+++ b/koco/src/pages/ProblemListPage/components/ProblemItem/index.tsx
@@ -4,13 +4,25 @@ interface IProblemItemProps {
   problemNumber: number;
   title: string;
   tier: string;
+  isAnswered: boolean;
+  problemSetId: number;
 }
 
-const ProblemItem = ({ problemNumber, title, tier }: IProblemItemProps) => {
+const ProblemItem = ({
+  problemNumber,
+  title,
+  tier,
+  isAnswered,
+  problemSetId,
+}: IProblemItemProps) => {
   const navigate = useNavigate();
 
   const handleClick = () => {
-    navigate(`/problems/${problemNumber}`);
+    if (isAnswered) {
+      navigate(`/problems/${problemNumber}`);
+    } else {
+      navigate('/survey', { state: { problemSetId: problemSetId } });
+    }
   };
 
   return (

--- a/koco/src/pages/ProblemListPage/index.tsx
+++ b/koco/src/pages/ProblemListPage/index.tsx
@@ -19,9 +19,11 @@ const ProblemListPage = () => {
       <PageHeader title="문제 해설" />
       <Calendar date={date} handleDate={handleDate} />
       <hr className="border-border" />
-      {problemListData.problems.map(problem => (
+      {problemListData?.problems.map(problem => (
         <ProblemItem
           key={problem.problemId}
+          problemSetId={problemListData?.problemSetId}
+          isAnswered={problemListData?.isAnswered}
           problemNumber={problem.problemNumber}
           title={problem.tier}
           tier={problem.tier}

--- a/koco/src/pages/ProblemSolutionPage/components/ProblemDetailSection/index.tsx
+++ b/koco/src/pages/ProblemSolutionPage/components/ProblemDetailSection/index.tsx
@@ -9,7 +9,7 @@ const ProblemDetailSection = (data: IGetProblemSolutionResponse) => {
         <span>다음 문제 &gt;</span>
       </div>
       <h1 className="text-xl font-bold">
-        {data.problemNumber}번 {data.title}
+        {data?.problemNumber}번 {data.title}
       </h1>
 
       {/* 제한 조건 테이블 */}

--- a/koco/src/pages/ProblemSolutionPage/components/ProblemSolutionSection/index.tsx
+++ b/koco/src/pages/ProblemSolutionPage/components/ProblemSolutionSection/index.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 
 interface ISolutionProps {
-  explanation: string;
-  solutionCode: { cpp: string; java: string; python: string };
+  explanation?: string;
+  solutionCode?: { cpp?: string; java?: string; python?: string };
 }
 
 const ProblemSolutionSection = ({ explanation, solutionCode }: ISolutionProps) => {
@@ -28,10 +28,10 @@ const ProblemSolutionSection = ({ explanation, solutionCode }: ISolutionProps) =
         </div>
         <div className="bg-black text-white text-sm rounded-md overflow-x-auto p-4 font-mono">
           {selectedLanguage === 'cpp'
-            ? solutionCode.cpp
+            ? solutionCode?.cpp
             : selectedLanguage === 'java'
-              ? solutionCode.java
-              : solutionCode.python}
+              ? solutionCode?.java
+              : solutionCode?.python}
         </div>
       </div>
     </section>

--- a/koco/src/pages/ProblemSolutionPage/index.tsx
+++ b/koco/src/pages/ProblemSolutionPage/index.tsx
@@ -8,12 +8,37 @@ import { useParams } from 'react-router-dom';
 const ProblemSolutionPage = () => {
   const { id } = useParams();
   const numericId = id ? parseInt(id, 10) : undefined;
-  const { data: solutionData } = useProblemSolution(numericId as number);
+  const { data: solutionData, isLoading, isError } = useProblemSolution(numericId as number);
+
+  // 로딩 중이거나 데이터가 없는 경우 로딩 표시
+  if (isLoading) {
+    return (
+      <div>
+        <PageHeader title="문제 해설" />
+        <div className="flex justify-center items-center h-[60vh]">
+          <p>로딩 중...</p>
+        </div>
+        <BottomNav />
+      </div>
+    );
+  }
+
+  if (isError || !solutionData) {
+    return (
+      <div>
+        <PageHeader title="문제 해설" />
+        <div className="flex justify-center items-center h-[60vh]">
+          <p>해설 정보가 없습니다</p>
+        </div>
+        <BottomNav />
+      </div>
+    );
+  }
 
   return (
     <div>
       <PageHeader title="문제 해설" />
-      <div className=" shadow-md">
+      <div className="shadow-md">
         <ProblemDetailSection {...solutionData} />
         <ProblemSolutionSection
           explanation={solutionData.problemCheck}

--- a/koco/src/pages/SurveyPage/index.tsx
+++ b/koco/src/pages/SurveyPage/index.tsx
@@ -78,7 +78,7 @@ const SurveyPage = () => {
   };
 
   useEffect(() => {
-    if (problemListData.problems.length > 0) {
+    if (problemListData?.problems) {
       const initialSurveyData = problemListData.problems.map((problem: Problem) => ({
         problemId: problem.problemId,
         isSolved: null,
@@ -86,12 +86,12 @@ const SurveyPage = () => {
       }));
       setSurveyData(initialSurveyData);
     }
-  }, [problemListData.problems]);
+  }, [problemListData?.problems]);
 
   return (
     <div className="bg-background min-h-screen">
       <PageHeader title="설문" />
-      {problemListData.problems.map((problem: Problem) => (
+      {problemListData?.problems.map((problem: Problem) => (
         <QuestionCard
           key={problem.problemId}
           problemId={problem.problemId}

--- a/koco/src/provider/QueryProvider/index.tsx
+++ b/koco/src/provider/QueryProvider/index.tsx
@@ -13,7 +13,7 @@ const QueryProvider = ({ children }: { children: React.ReactNode }) => {
             staleTime: 1000 * 60 * 5, // 5분
             gcTime: 1000 * 60 * 10, // 10분
             retry: 3,
-            refetchOnWindowFocus: true,
+            refetchOnWindowFocus: false,
             refetchOnMount: false,
           },
           mutations: {

--- a/koco/src/temp/mock/dashboard.ts
+++ b/koco/src/temp/mock/dashboard.ts
@@ -5,7 +5,7 @@ const MOCK_DASHBOARD_DATA: IGetUserDashboardResponse = {
   nickname: '지연우',
   statusMessage: '솔브닥 스트릭 100일 채우자',
   profileImgUrl: '../../../assets/defaultProfileImage.png',
-  todayProblemSetId: 32,
+  todayProblemSetId: 1,
   continuousAttendance: 5,
   studyStats: [
     {


### PR DESCRIPTION
# TITLE
[CHORE] API 연결 수정 (#21)

## 📝 개요
백엔드 로컬 서버를 기반으로 api 연결을 테스트 하였으며 일부 라우팅 로직을 수정하였습니다.

## 🔗 연관된 이슈
- close #21 

## 🔄 변경사항 및 이유
- bottom navigation의 코드 해설집 바로가기 라우팅 수정
- 기타 api 연결 및 더미데이터 제거, 타입 수정

## 📋 작업할 내용
- [x] 백엔드 로컬 환경 세팅
- [x] api 연결 및 테스트
- [x] 설문하지 않은 문제 클릭 시 해당 문제의 설문 페이지로 이동하는 로직 구현
- [x]  /complete-profile 페이지에서 multipart/form-data 형식으로 백엔드에 api 요청하는 로직 구현
- [x] 존재하지 않는 문제 번호로 이동 시 처리하는 로직 구현

## 🔖 기타사항
- 백엔드 개발 상황에 따라 메인페이지 api 연결 및 테스트 필요 (미완료)
- 라우팅 경로 제한(문제 해설 페이지)하는 로직 구현 필요

## 👀 리뷰 요구사항

## 🔗 참고 자료 