### PR TITLE
[CHORE] QA 모드 설정 (#34)

### DIFF
--- a/koco/src/routes/RootRoutes.tsx
+++ b/koco/src/routes/RootRoutes.tsx
@@ -12,7 +12,7 @@ import { AuthProvider } from '@/context/AuthContext';
 
 const RootRoutes = () => {
   return (
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.NODE_ENV === 'qa' ? '/admin-preview' : '/'}>
       <AuthProvider>
         <Routes>
           <Route element={<AppLayout />}>

--- a/koco/tsconfig.json
+++ b/koco/tsconfig.json
@@ -5,7 +5,9 @@
     "baseUrl": ".", // 현재 프로젝트 루트 기준
     "paths": {
       "@/*": ["src/*"] //"@/components/Button" → "src/components/Button"
-    }
+    },
+    "include": ["src", "vite-env.d.ts"],
+    "types": ["vite/client"]
   }
   // tsconfig.json
 }

--- a/koco/vite.config.ts
+++ b/koco/vite.config.ts
@@ -1,9 +1,18 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import tailwindcss from '@tailwindcss/vite';
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react(), tsconfigPaths(), tailwindcss()],
+export default defineConfig(({ mode }) => {
+  // Load env file based on `mode` in the current directory.
+  // Set the third parameter to '' to load all env regardless of the `VITE_` prefix.
+  const env = loadEnv(mode, process.cwd(), '');
+
+  const isQA = env.VITE_IS_QA === 'qa';
+
+  return {
+    plugins: [react(), tsconfigPaths(), tailwindcss()],
+    base: isQA ? '/admin-preview/' : '/',
+  };
 });


### PR DESCRIPTION
# TITLE
[CHORE] QA 모드 설정 (#34)

## 📝 개요
QA 모드일 시 /admin/preview 경로로 이동하도록 설정

## 🔗 연관된 이슈
- closes #34

## 🔄 변경사항 및 이유
- vite.config.ts 설정을 수정하였으며, BrowserRouter의 basename을 수정하였습니다.

## 📋 작업할 내용
- [x] vite.config.ts 설정
- [x] 테스트

## 🔖 기타사항
- [ ] 클라우드 측 테스트 필요


## 👀 리뷰 요구사항 (선택)

## 🔗 참고 자료 (선택)

