### PR TITLE
[BUG] 문제 데이터가 없을 시에도 설문 제출이 가능한 현상 수정 (#38)

### DIFF
--- a/koco/src/pages/SurveyPage/index.tsx
+++ b/koco/src/pages/SurveyPage/index.tsx
@@ -103,12 +103,12 @@ const SurveyPage = () => {
           }
         />
       ))}
-      {problemListData?.problems && (
+      {problemListData?.problems?.length > 0 && (
         <Button className="mt-6 w-full" disabled={!allAnswered} onClick={handleSubmitSurvey}>
           오늘의 해설집 확인하기
         </Button>
       )}
-      {!problemListData?.problems && (
+      {!(problemListData?.problems?.length > 0) && (
         <div className="flex flex-col items-center justify-center p-10">
           <p>오늘의 문제가 존재하지 않습니다</p>
         </div>

--- a/koco/src/pages/SurveyPage/index.tsx
+++ b/koco/src/pages/SurveyPage/index.tsx
@@ -103,10 +103,16 @@ const SurveyPage = () => {
           }
         />
       ))}
-
-      <Button className="mt-6 w-full" disabled={!allAnswered} onClick={handleSubmitSurvey}>
-        오늘의 해설집 확인하기
-      </Button>
+      {problemListData?.problems && (
+        <Button className="mt-6 w-full" disabled={!allAnswered} onClick={handleSubmitSurvey}>
+          오늘의 해설집 확인하기
+        </Button>
+      )}
+      {!problemListData?.problems && (
+        <div className="flex flex-col items-center justify-center p-10">
+          <p>오늘의 문제가 존재하지 않습니다</p>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
# TITLE
[BUG] 문제 데이터가 없을 시에도 설문 제출이 가능한 현상 수정 (#38)

## 📝 개요
문제 데이터가 없을 경우 설문 페이지의 '오늘의 문제가 없습니다'가 띄워지도록 구현

## 🔗 연관된 이슈
- close #38 

## 🔄 변경사항 및 이유
- 문제 데이터가 없을 경우 '오늘의 문제 데이터가 없습니다' 문구가 띄워지도록 수정, 설문 등록 버튼이 보이지 않도록 수정

## 📋 작업할 내용
- [x] 설문 페이지 UI 수정

## 🔖 기타사항

## 👀 리뷰 요구사항 (선택)


## 🔗 참고 자료 (선택)
