### PR TITLE
[BUG] logo click event 제거 (#42)

### DIFF
--- a/koco/src/components/layout/Header/index.tsx
+++ b/koco/src/components/layout/Header/index.tsx
@@ -1,16 +1,9 @@
 import Logo from '@/assets/Logo.svg';
-import { useNavigate } from 'react-router-dom';
 
 const Header = () => {
-  const navigate = useNavigate();
-
-  const handleBack = () => {
-    navigate(-1);
-  };
-
   return (
     <header className="text-center h-16 flex items-center justify-center">
-      <img src={Logo} width={30} height={40} onClick={handleBack} />
+      <img src={Logo} width={30} height={40} />
       <h1 className="text-2xl">KOCO</h1>
     </header>
   );


### PR DESCRIPTION
# TITLE
[BUG] logo click event 제거 (#42)

## 📝 개요
로고를 클릭 했을 때 이전 작업으로 이동하는 이벤트가 적용되어 있던 것을 제거합니다.

## 🔗 연관된 이슈
- closes #42 

## 🔄 변경사항 및 이유
- 로고 클릭 시 navigate(-1)이 실행되었지만, 로고를 클릭했을 때 실행할 이벤트는 없어야 하므로 제거하였습니다.

## 📋 작업할 내용
- [x] 로고 클릭 이벤트 제거

## 🔖 기타사항

## 👀 리뷰 요구사항 (선택)


## 🔗 참고 자료 (선택)

