### PR TITLE
[FEATURE] 오늘의 설문 한 번만 수행할 수 있도록 수정 (#41, #45)

### DIFF
--- a/koco/src/@types/problem/index.ts
+++ b/koco/src/@types/problem/index.ts
@@ -1,6 +1,5 @@
 export interface IProblemSurvey {
   problemId: number;
-  problemNumber: number;
   isSolved: boolean;
   difficultyLevel: string;
 }

--- a/koco/src/pages/MainPage/components/ProfileCard/index.tsx
+++ b/koco/src/pages/MainPage/components/ProfileCard/index.tsx
@@ -16,6 +16,7 @@ const ProfileCard = ({
   problemSetId,
 }: IProfileCardProps) => {
   const navigate = useNavigate();
+  const todayDate = new Date().toISOString().split('T')[0];
 
   return (
     <Card className="p-4">
@@ -33,7 +34,9 @@ const ProfileCard = ({
         </div>
         <Button
           className="bg-secondary hover:bg-secondary-hover w-full"
-          onClick={() => navigate('/survey', { state: { problemSetId: problemSetId } })}
+          onClick={() =>
+            navigate('/survey', { state: { problemSetId: problemSetId, date: todayDate } })
+          }
         >
           오늘의 학습 설문하고 해설보기
         </Button>

--- a/koco/src/pages/ProblemListPage/components/ProblemItem/index.tsx
+++ b/koco/src/pages/ProblemListPage/components/ProblemItem/index.tsx
@@ -6,6 +6,7 @@ interface IProblemItemProps {
   tier: string;
   isAnswered: boolean;
   problemSetId: number;
+  date: string;
 }
 
 const ProblemItem = ({
@@ -14,6 +15,7 @@ const ProblemItem = ({
   tier,
   isAnswered,
   problemSetId,
+  date,
 }: IProblemItemProps) => {
   const navigate = useNavigate();
 
@@ -53,11 +55,14 @@ const ProblemItem = ({
 
   const tierColor = getTierColor(tierRank);
 
+  console.log(isAnswered);
+
   const handleClick = () => {
     if (isAnswered) {
       navigate(`/problems/${problemNumber}`);
     } else {
-      navigate('/survey', { state: { problemSetId: problemSetId } });
+      alert('설문이 기록되지 않았습니다. 설문페이지로 이동합니다');
+      navigate('/survey', { state: { problemSetId: problemSetId, date: date } });
     }
   };
 

--- a/koco/src/pages/ProblemListPage/components/ProblemItem/index.tsx
+++ b/koco/src/pages/ProblemListPage/components/ProblemItem/index.tsx
@@ -26,7 +26,32 @@ const ProblemItem = ({
   };
 
   const tierRank = getTierRank(tier);
-  const tierClassName = `bg-tier-${tierRank}`;
+  // const tierClassName = `bg-tier-${tierRank}`;
+  // console.log(tierRank, tierClassName);
+
+  // 티어 색상 가져오기 함수
+  const getTierColor = (rank: string): string => {
+    switch (rank) {
+      case 'bronze':
+        return '#AD5600';
+      case 'silver':
+        return '#435F7A';
+      case 'gold':
+        return '#EC9A00';
+      case 'platinum':
+        return '#27E2A4';
+      case 'diamond':
+        return '#00B4FC';
+      case 'ruby':
+        return '#FF0062';
+      case 'master':
+        return '#9D0191';
+      default:
+        return '#777777'; // unrated
+    }
+  };
+
+  const tierColor = getTierColor(tierRank);
 
   const handleClick = () => {
     if (isAnswered) {
@@ -42,9 +67,15 @@ const ProblemItem = ({
       className="flex items-center justify-between cursor-pointer p-4 hover:bg-gray-100 rounded-md"
     >
       <div className="flex items-center gap-2">
-        <div className={`${tierClassName} text-white text-xs px-2 py-1 rounded-md font-bold`}>
+        <div
+          className="text-white text-xs px-2 py-1 rounded-md font-bold"
+          style={{ backgroundColor: tierColor }}
+        >
           {tier}
         </div>
+        {/* <div className={`${tierClassName} text-white text-xs px-2 py-1 rounded-md font-bold`}>
+          {tier}
+        </div> */}
         <div className="flex flex-col">
           <span className="font-bold text-sm">#{problemNumber}번</span>
           <span className="text-sm">{title}</span>

--- a/koco/src/pages/ProblemListPage/index.tsx
+++ b/koco/src/pages/ProblemListPage/index.tsx
@@ -22,6 +22,7 @@ const ProblemListPage = () => {
       {problemListData?.problems.map(problem => (
         <ProblemItem
           key={problem.problemId}
+          date={problemListData?.date}
           problemSetId={problemListData?.problemSetId}
           isAnswered={problemListData?.isAnswered}
           problemNumber={problem.problemNumber}

--- a/koco/src/pages/SurveyPage/index.tsx
+++ b/koco/src/pages/SurveyPage/index.tsx
@@ -41,6 +41,7 @@ const SurveyPage = () => {
     item => item.isSolved !== null && item.difficultyLevel !== ''
   );
 
+  // 설문 데이터를 저장합니다
   const handleQuestionChange = (
     problemId: number,
     data: { isSolved?: boolean; difficultyLevel?: string }
@@ -50,12 +51,13 @@ const SurveyPage = () => {
     );
   };
 
+  // api를 호출해 설문 데이터를 전송합니다
   const handleSubmitSurvey = () => {
     const requestData: IProblemSurveyRequest = {
       problemSetId: problemSetId,
-      responses: surveyData.map((item, index) => ({
+      responses: surveyData.map(item => ({
         problemId: item.problemId,
-        problemNumber: index + 1,
+        //problemNumber: index + 1,
         isSolved: item.isSolved === null ? false : item.isSolved,
         difficultyLevel:
           item.difficultyLevel === '쉬웠어요'
@@ -79,6 +81,12 @@ const SurveyPage = () => {
 
   useEffect(() => {
     if (problemListData?.problems) {
+      if (problemListData?.isAnswered) {
+        alert('이미 완료한 설문입니다');
+        navigate('/');
+
+        return;
+      }
       const initialSurveyData = problemListData.problems.map((problem: Problem) => ({
         problemId: problem.problemId,
         isSolved: null,
@@ -103,12 +111,12 @@ const SurveyPage = () => {
           }
         />
       ))}
-      {problemListData?.problems?.length > 0 && (
+      {problemListData && problemListData.problems.length > 0 && (
         <Button className="mt-6 w-full" disabled={!allAnswered} onClick={handleSubmitSurvey}>
           오늘의 해설집 확인하기
         </Button>
       )}
-      {!(problemListData?.problems?.length > 0) && (
+      {problemListData && problemListData.problems.length === 0 && (
         <div className="flex flex-col items-center justify-center p-10">
           <p>오늘의 문제가 존재하지 않습니다</p>
         </div>

--- a/koco/src/pages/SurveyPage/index.tsx
+++ b/koco/src/pages/SurveyPage/index.tsx
@@ -29,13 +29,12 @@ export interface IProblemSetResponse {
 const SurveyPage = () => {
   const location = useLocation();
   const problemSetId = Number(location.state?.problemSetId);
+  const targetDate = location.state?.date;
 
   const navigate = useNavigate();
   const [surveyData, setSurveyData] = useState<ISurveyData[]>([]);
   const registerSurveyMutation = useRegisterSurvey();
-
-  const todayDate = new Date().toISOString().split('T')[0];
-  const { data: problemListData } = useProblemSet(todayDate);
+  const { data: problemListData } = useProblemSet(targetDate);
 
   const allAnswered = surveyData.every(
     item => item.isSolved !== null && item.difficultyLevel !== ''
@@ -70,11 +69,12 @@ const SurveyPage = () => {
 
     registerSurveyMutation.mutate(requestData, {
       onSuccess: () => {
-        navigate('/problems');
+        window.location.href = '/problems';
       },
       onError: () => {
         console.log(requestData);
-        navigate('/problems');
+        alert('설문 등록에 실패하였습니다');
+        window.location.href = '/problems';
       },
     });
   };


### PR DESCRIPTION
# TITLE
[FEATURE] 오늘의 설문 한 번만 수행할 수 있도록 수정 (#41)

## 📝 개요
설문 관련한 버그를 수정하고, 오늘의 설문을 한 번만 수행할 수 있도록 수정하였습니다.

## 🔗 연관된 이슈
closes #41 #45 

## 🔄 변경사항 및 이유
navigate 시 state로 date를 보내게 하여, 문제 리스트 조회 시 설문이 완료 되지 않은 경우 해당 날짜의 설문으로 정상적으로 이동할 수 있도록 수정하였습니다.
오늘의 설문은 isAnswered에 따라 한 번만 수행할 수 있도록 로직을 수정하였습니다.

## 📋 작업할 내용
- [x] 문제 리스트 조회 -> 설문 페이지 이동 시 발생하는 버그 수정
- [x] 오늘의 설문 한 번만 수행하도록 로직 변경

## 🔖 기타사항

## 👀 리뷰 요구사항 (선택)


## 🔗 참고 자료 (선택)

