### PR TITLE
[FEATURE] 백준 티어 랭킹 데이터 문자열로 매핑 (#50)

### DIFF
--- a/koco/src/pages/ProblemListPage/components/ProblemItem/index.tsx
+++ b/koco/src/pages/ProblemListPage/components/ProblemItem/index.tsx
@@ -1,3 +1,4 @@
+import { formatBaekjoonTier } from '@/utils/converter/convertTier';
 import { useNavigate } from 'react-router-dom';
 
 interface IProblemItemProps {
@@ -24,29 +25,27 @@ const ProblemItem = ({
     if (!tier) return 'unrated';
     const [rank] = tier.split(' ');
 
-    return rank?.toLowerCase() || 'unrated';
+    return rank || 'unrated';
   };
-
-  const tierRank = getTierRank(tier);
-  // const tierClassName = `bg-tier-${tierRank}`;
-  // console.log(tierRank, tierClassName);
+  const tierWithSublevel = formatBaekjoonTier(tier);
+  const tierRank = getTierRank(tierWithSublevel);
 
   // 티어 색상 가져오기 함수
   const getTierColor = (rank: string): string => {
     switch (rank) {
-      case 'bronze':
+      case 'Bronze':
         return '#AD5600';
-      case 'silver':
+      case 'Silver':
         return '#435F7A';
-      case 'gold':
+      case 'Gold':
         return '#EC9A00';
-      case 'platinum':
+      case 'Platinum':
         return '#27E2A4';
-      case 'diamond':
+      case 'Diamond':
         return '#00B4FC';
-      case 'ruby':
+      case 'Ruby':
         return '#FF0062';
-      case 'master':
+      case 'Master':
         return '#9D0191';
       default:
         return '#777777'; // unrated
@@ -54,8 +53,6 @@ const ProblemItem = ({
   };
 
   const tierColor = getTierColor(tierRank);
-
-  console.log(isAnswered);
 
   const handleClick = () => {
     if (isAnswered) {
@@ -76,7 +73,7 @@ const ProblemItem = ({
           className="text-white text-xs px-2 py-1 rounded-md font-bold"
           style={{ backgroundColor: tierColor }}
         >
-          {tier}
+          {tierWithSublevel}
         </div>
         {/* <div className={`${tierClassName} text-white text-xs px-2 py-1 rounded-md font-bold`}>
           {tier}

--- a/koco/src/pages/ProblemSolutionPage/components/ProblemDetailSection/index.tsx
+++ b/koco/src/pages/ProblemSolutionPage/components/ProblemDetailSection/index.tsx
@@ -58,7 +58,7 @@ const ProblemDetailSection = (data: IGetProblemSolutionResponse) => {
         </div>
         <div>
           <h3 className="font-semibold mb-1">예시 출력</h3>
-          <pre className="bg-gray-100 p-3 rounded">{data.outputExample}</pre>
+          <pre className="bg-gray-100 p-3 rounded whitespace-pre-line">{data.outputExample}</pre>
         </div>
       </div>
     </section>

--- a/koco/src/utils/converter/convertTier.ts
+++ b/koco/src/utils/converter/convertTier.ts
@@ -1,0 +1,52 @@
+/**
+ * 백준 티어 숫자 값을 사람이 읽기 쉬운 형식으로 변환합니다.
+ * 예: "0" -> "Unrated", "5.0" -> "Bronze 1", "30.0" -> "Ruby 1" 등
+ *
+ * @param tierValue 백준에서 제공하는 티어 값 (문자열)
+ * @returns 읽기 쉬운 티어 이름 (예: "Silver 1")
+ */
+
+export const formatBaekjoonTier = (tierValue: string): string => {
+  // 입력값이 없거나 "0"인 경우 Unrated 반환
+  if (!tierValue || tierValue === '0') return 'Unrated';
+
+  try {
+    // 소수점으로 분리
+    const [level] = tierValue.split('.').map(Number);
+
+    // 티어 및 서브레벨 결정
+    let tier: string;
+    let subLevel: number;
+
+    if (level <= 5) {
+      tier = 'Bronze';
+      subLevel = 5 - ((level - 1) % 5);
+    } else if (level <= 10) {
+      tier = 'Silver';
+      subLevel = 5 - ((level - 6) % 5);
+    } else if (level <= 15) {
+      tier = 'Gold';
+      subLevel = 5 - ((level - 11) % 5);
+    } else if (level <= 20) {
+      tier = 'Platinum';
+      subLevel = 5 - ((level - 16) % 5);
+    } else if (level <= 25) {
+      tier = 'Diamond';
+      subLevel = 5 - ((level - 21) % 5);
+    } else if (level <= 30) {
+      tier = 'Ruby';
+      subLevel = 5 - ((level - 26) % 5);
+    } else if (level <= 35) {
+      tier = 'Master';
+      subLevel = 5 - ((level - 31) % 5);
+    } else {
+      return 'Unrated'; // 알 수 없는 레벨
+    }
+
+    return `${tier} ${subLevel}`;
+  } catch (error) {
+    console.error('티어 변환 중 오류 발생:', error);
+
+    return 'Unrated';
+  }
+};


### PR DESCRIPTION
# TITLE
[FEATURE] 백준 티어 랭킹 데이터 문자열로 매핑 (#50)

## 📝 개요
기존의 백준 티어 데이터가 '6.0'으로 오던 것을 'Silver 5'와 같은 형태로 변환하도록 유틸 함수를 구현하였습니다.

## 🔗 연관된 이슈
- closes #50 
## 🔄 변경사항 및 이유
- 티어 데이터가 숫자로 표시되는 이슈가 있어 수정하였습니다.
- 문제 해설 페이지의 데이터 출력 부분에 whitespace-pre-line 클래스를 적용하지 않은 것을 발견하여 수정하였습니다.

## 📋 작업할 내용
- [x] 티어 데이터 매핑 함수 구현

## 🔖 기타사항

## 👀 리뷰 요구사항 (선택)

## 🔗 참고 자료 (선택)
