### PR TITLE
[CHORE] 설문 페이지 - 데이터가 비어 있을 경우 핸들링 (#58)

### DIFF
--- a/koco/src/pages/SurveyPage/index.tsx
+++ b/koco/src/pages/SurveyPage/index.tsx
@@ -6,6 +6,7 @@ import PageHeader from '@/components/layout/PageHeader';
 import { useRegisterSurvey } from '@/hooks/mutations/useProblemMutations';
 import { IProblemSurveyRequest } from '@/@types/problem';
 import { useProblemSet } from '@/hooks/queries/useProblemQueries';
+import { AxiosError } from 'axios';
 
 interface ISurveyData {
   problemId: number;
@@ -34,7 +35,7 @@ const SurveyPage = () => {
   const navigate = useNavigate();
   const [surveyData, setSurveyData] = useState<ISurveyData[]>([]);
   const registerSurveyMutation = useRegisterSurvey();
-  const { data: problemListData } = useProblemSet(targetDate);
+  const { data: problemListData, error } = useProblemSet(targetDate);
 
   const allAnswered = surveyData.every(
     item => item.isSolved !== null && item.difficultyLevel !== ''
@@ -96,6 +97,17 @@ const SurveyPage = () => {
     }
   }, [problemListData?.problems]);
 
+  if ((error as AxiosError)?.response?.status === 403) {
+    return (
+      <div className="bg-background min-h-screen">
+        <PageHeader title="설문" />
+        <div className="flex flex-col items-center justify-center p-12">
+          <p>오늘의 문제가 존재하지 않습니다</p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="bg-background min-h-screen">
       <PageHeader title="설문" />
@@ -116,7 +128,7 @@ const SurveyPage = () => {
           오늘의 해설집 확인하기
         </Button>
       )}
-      {problemListData && problemListData.problems.length === 0 && (
+      {problemListData && !problemListData.problems && (
         <div className="flex flex-col items-center justify-center p-10">
           <p>오늘의 문제가 존재하지 않습니다</p>
         </div>


### PR DESCRIPTION
# TITLE
[CHORE] 데이터가 비어 있을 경우 핸들링 (#58)

## 📝 개요
오늘의 설문 데이터가 비어 있을 경우 보여줄 UI 구현

## 🔗 연관된 이슈
closes #58 

## 🔄 변경사항 및 이유
- react-query의 error 변수를 사용하여 403 코드일 경우 '오늘의 문제가 없습니다' 렌더링하도록 구현하였습니다.

## 📋 작업할 내용
- [x] 엣지 케이스 핸들링

## 🔖 기타사항

## 👀 리뷰 요구사항 (선택)


## 🔗 참고 자료 (선택)
- 관련 문서나 링크가 있으면 첨부
