### PR TITLE
[BUG] 문제 리스트 조회 페이지 - 날짜 선택 시 쿼리 파라미터 변동 및 refetch 하도록 로직 수정 (#57)

### DIFF
--- a/koco/src/pages/ProblemListPage/index.tsx
+++ b/koco/src/pages/ProblemListPage/index.tsx
@@ -2,34 +2,69 @@ import PageHeader from '@/components/layout/PageHeader';
 import Calendar from './components/Calendar';
 import ProblemItem from './components/ProblemItem';
 import { useProblemSet } from '@/hooks/queries/useProblemQueries';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { AxiosError } from 'axios';
 
 const ProblemListPage = () => {
   const todayDate = new Date().toISOString().split('T')[0];
-  const [date, setDate] = useState(todayDate);
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const dateFromUrl = searchParams.get('date');
 
-  const { data: problemListData } = useProblemSet(date);
+  // 초기 날짜 설정 - URL의 date 파라미터를 우선적으로 사용
+  const [date, setDate] = useState(dateFromUrl || todayDate);
+
+  const { data: problemListData, error, refetch } = useProblemSet(date);
+
+  // URL의 date 파라미터가 변경되면 date 상태도 업데이트
+  useEffect(() => {
+    if (dateFromUrl && dateFromUrl !== date) {
+      setDate(dateFromUrl);
+    }
+  }, [dateFromUrl]);
 
   const handleDate = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setDate(e.target.value);
+    const newDate = e.target.value;
+    setDate(newDate);
+
+    navigate(`/problems?date=${encodeURIComponent(newDate)}`, { replace: true });
+
+    // 날짜가 변경되면 명시적으로 데이터 다시 가져오기
+    setTimeout(() => refetch(), 0);
   };
+
+  if ((error as AxiosError)?.response?.status === 403) {
+    return (
+      <div className="bg-background min-h-screen">
+        <PageHeader title="문제 해설" />
+        <Calendar date={date} handleDate={handleDate} />
+        <hr className="border-border" />
+        <p className="text-center mt-12">해당 날짜의 문제가 존재하지 않습니다</p>
+      </div>
+    );
+  }
 
   return (
     <div className="bg-background min-h-screen">
       <PageHeader title="문제 해설" />
       <Calendar date={date} handleDate={handleDate} />
       <hr className="border-border" />
-      {problemListData?.problems.map(problem => (
-        <ProblemItem
-          key={problem.problemId}
-          date={problemListData?.date}
-          problemSetId={problemListData?.problemSetId}
-          isAnswered={problemListData?.isAnswered}
-          problemNumber={problem.problemNumber}
-          title={problem.title}
-          tier={problem.tier}
-        />
-      ))}
+      {problemListData?.problems && problemListData.problems.length > 0 ? (
+        problemListData.problems.map(problem => (
+          <ProblemItem
+            key={problem.problemId}
+            date={problemListData?.date}
+            problemSetId={problemListData?.problemSetId}
+            isAnswered={problemListData?.isAnswered}
+            problemNumber={problem.problemNumber}
+            title={problem.title}
+            tier={problem.tier}
+          />
+        ))
+      ) : (
+        <p className="text-center mt-12">로딩 중이거나 문제가 없습니다</p>
+      )}
     </div>
   );
 };

--- a/koco/src/pages/SurveyPage/index.tsx
+++ b/koco/src/pages/SurveyPage/index.tsx
@@ -70,7 +70,7 @@ const SurveyPage = () => {
 
     registerSurveyMutation.mutate(requestData, {
       onSuccess: () => {
-        window.location.href = '/problems';
+        window.location.href = `/problems?date=${encodeURIComponent(targetDate)}`;
       },
       onError: () => {
         console.log(requestData);


### PR DESCRIPTION
# TITLE
[BUG] 문제 리스트 조회 페이지 - 날짜 선택 시 쿼리 파라미터 변동 및 refetch 하도록 로직 수정 (#57)

## 📝 개요
설문 등록 후 다시 해당 문제로 돌아왔을 때 현재 날짜로 선택되어 있는 버그를 수정하였습니다.

## 🔗 연관된 이슈
- closes #57 

## 🔄 변경사항 및 이유
- 설문 등록 후 /problems 페이지로 이동하는 라우팅을 /problems?date=2025-05-12 와 같이 쿼리 파라미터로 date를 넘기는 로직으로 수정하였습니다.
- 문제 리스트 조회 페이지에서 date를 선택할 때마다 query parameter가 변동되어, refetch하도록 수정하였습니다.

## 📋 작업할 내용
- [x] 설문 페이지에서 문제 리스트 조회 이동 시 date를 넘기도록 라우팅 수정
- [x] 날짜 선택할 때마다 쿼리 파라미터가 변경되도록 수정, 이에 따라 문제 리스트 refetch하도록 로직 수정

## 🔖 기타사항
- 최적화가 필요할 것으로 예상됩니다.

## 👀 리뷰 요구사항 (선택)

## 🔗 참고 자료 (선택)

