### PR TITLE
[FEATURE] 메인 페이지 - 유저 프로필 조회, 알고리즘 스탯 조회 API 연결 (#69)

### DIFF
--- a/koco/src/@types/user/index.ts
+++ b/koco/src/@types/user/index.ts
@@ -13,3 +13,20 @@ export interface IStudyStat {
   categoryName: string;
   correctRate: number;
 }
+
+export interface IGetUserProfileResponse {
+  userId: number;
+  nickname: string;
+  statusMessage: string;
+  profileImageUrl: string;
+}
+
+export interface IStudyStat {
+  categoryId: number;
+  categoryName: string;
+  correctRate: number;
+}
+
+export interface IStudyStatsResponse {
+  studyStats: IStudyStat[];
+}

--- a/koco/src/apis/axios/index.ts
+++ b/koco/src/apis/axios/index.ts
@@ -59,6 +59,8 @@ axiosInstance.interceptors.response.use(
         const success = await refreshToken();
 
         if (success) {
+          console.log('토큰이 리프레쉬 되었습니다');
+
           return axiosInstance(originalRequest);
         } else {
           // 토큰 갱신 실패 시 로그인 페이지로

--- a/koco/src/apis/userApi.ts
+++ b/koco/src/apis/userApi.ts
@@ -1,5 +1,9 @@
 // src/apis/userApi.ts
-import { IGetUserDashboardResponse } from '@/@types/user';
+import {
+  IGetUserDashboardResponse,
+  IGetUserProfileResponse,
+  IStudyStatsResponse,
+} from '@/@types/user';
 import axios from './axios';
 import { IApiResponse } from '@/@types/api';
 
@@ -40,6 +44,28 @@ export const getUserDashboard = async (date: string) => {
   return response.data.data;
 };
 
+/**
+ * GET) 사용자 정보 조회
+ * @returns userId, nickname, statusMessage, profileImageUrl
+ */
+export const getUserProfile = async () => {
+  const response = await axios.get<IApiResponse<IGetUserProfileResponse>>(`${V1_SUB_URL}/me`);
+  console.log(response.data);
+
+  return response.data.data;
+};
+
+/**
+ * Get) 사용자 알고리즘 스탯 조회
+ * @returns studyStats
+ */
+export const getUserStudyStats = async () => {
+  const response = await axios.get<IApiResponse<IStudyStatsResponse>>(
+    `${V1_SUB_URL}/algorithm-stats`
+  );
+
+  return response.data.data;
+};
 /**
  * DELETE) 탈퇴하기
  */

--- a/koco/src/hooks/queries/queryKeys.ts
+++ b/koco/src/hooks/queries/queryKeys.ts
@@ -1,7 +1,7 @@
 export const queryKeys = {
   users: {
     all: ['users'] as const,
-    dashboard: (date: string) => [...queryKeys.users.all, 'dashboard', date] as const,
+    stats: ['users', 'stats'] as const,
     profile: ['users', 'profile'] as const,
   },
 

--- a/koco/src/hooks/queries/useUserQueries.ts
+++ b/koco/src/hooks/queries/useUserQueries.ts
@@ -1,17 +1,41 @@
-import { getUserDashboard } from '@/apis/userApi';
+import { getUserProfile, getUserStudyStats } from '@/apis/userApi';
 import { useQuery } from '@tanstack/react-query';
 import { queryKeys } from './queryKeys';
 
 /**
+ * 기존 훅 (현재 사용 x)
  * 사용자 대시보드 데이터를 가져오는 React Query 훅
  * @param date 조회할 날짜 (YYYY-MM-DD 형식)
  */
-export const useUserDashboard = (date: string) => {
+// export const useUserDashboard = (date: string) => {
+//   return useQuery({
+//     queryKey: queryKeys.users.dashboard(date),
+//     //initialData: MOCK_DASHBOARD_DATA,
+//     queryFn: () => getUserDashboard(date),
+//     enabled: !!date, // date가 유효할 때만 쿼리 활성화
+//     staleTime: 1000 * 60 * 5,
+//   });
+// };
+
+/**
+ * 사용자 프로필 정보 조회
+ */
+export const useUserProfile = () => {
   return useQuery({
-    queryKey: queryKeys.users.dashboard(date),
+    queryKey: queryKeys.users.profile,
     //initialData: MOCK_DASHBOARD_DATA,
-    queryFn: () => getUserDashboard(date),
-    enabled: !!date, // date가 유효할 때만 쿼리 활성화
+    queryFn: () => getUserProfile(),
+    staleTime: 1000 * 60 * 5,
+  });
+};
+
+/**
+ * 사용자 알고리즘 스탯 조회
+ */
+export const useUserStats = () => {
+  return useQuery({
+    queryKey: queryKeys.users.stats,
+    queryFn: () => getUserStudyStats(),
     staleTime: 1000 * 60 * 5,
   });
 };

--- a/koco/src/pages/MainPage/components/ProfileCard/index.tsx
+++ b/koco/src/pages/MainPage/components/ProfileCard/index.tsx
@@ -6,15 +6,9 @@ interface IProfileCardProps {
   profileImgUrl: string;
   nickname: string;
   statusMessage: string;
-  problemSetId: number;
 }
 
-const ProfileCard = ({
-  profileImgUrl,
-  nickname,
-  statusMessage,
-  problemSetId,
-}: IProfileCardProps) => {
+const ProfileCard = ({ profileImgUrl, nickname, statusMessage }: IProfileCardProps) => {
   const navigate = useNavigate();
   const todayDate = new Date().toISOString().split('T')[0];
 
@@ -34,9 +28,7 @@ const ProfileCard = ({
         </div>
         <Button
           className="bg-secondary hover:bg-secondary-hover w-full"
-          onClick={() =>
-            navigate('/survey', { state: { problemSetId: problemSetId, date: todayDate } })
-          }
+          onClick={() => navigate('/survey', { state: { date: todayDate } })}
         >
           오늘의 학습 설문하고 해설보기
         </Button>

--- a/koco/src/pages/MainPage/index.tsx
+++ b/koco/src/pages/MainPage/index.tsx
@@ -1,15 +1,33 @@
 import BottomNav from '@/components/layout/BottomNav';
 import ProfileCard from './components/ProfileCard';
-import TotalStudyCard from './components/TotalStudyCard';
 import Header from '@/components/layout/Header';
-import { useUserDashboard } from '@/hooks/queries/useUserQueries';
+import { useUserProfile, useUserStats } from '@/hooks/queries/useUserQueries';
 import ChunsikCard from './components/ChunsikCard';
+import TotalStudyCard from './components/TotalStudyCard';
 
 const MainPage = () => {
-  const todayDate = new Date().toISOString().split('T')[0];
-  const { data: dashboardData, isLoading } = useUserDashboard(todayDate);
+  const { data: userProfileData, isLoading: isUserProfileLoading } = useUserProfile();
+  const { data: userStudyStatData, isLoading: isUserStudyStatLoading } = useUserStats();
 
-  if (isLoading) {
+  // 인증 에러 발생 시 로그인 페이지로 리디렉션
+  // useEffect(() => {
+  //   if (error || (!isLoading && !dashboardData)) {
+  //     console.error('데이터 불러오기 실패:', error);
+
+  //     console.log((error as AxiosError)?.response?.status);
+
+  //     if ((error as AxiosError)?.response?.status === 403) {
+  //       console.log('403 에러 발생, 로그인 페이지로 이동합니다');
+  //       // 로컬 스토리지의 인증 플래그 제거
+  //       localStorage.removeItem('koco_auth_flag');
+
+  //       //로그인 페이지로 리디렉션
+  //       window.location.href = '/';
+  //     }
+  //   }
+  // }, [error, dashboardData, isLoading]);
+
+  if (isUserProfileLoading || isUserStudyStatLoading) {
     return (
       <div className="flex flex-col gap-6 p-6 pb-30">
         <Header />
@@ -17,11 +35,12 @@ const MainPage = () => {
       </div>
     );
   }
-  if (!dashboardData) {
+
+  if (!userProfileData || !userStudyStatData) {
     return (
       <div className="flex flex-col gap-6 p-6 pb-30">
         <Header />
-        <p className="text-center">유저 데이터가 없습니다</p>
+        <p className="text-center">데이터를 불러올 수 없습니다. 다시 로그인해주세요.</p>
       </div>
     );
   }
@@ -30,12 +49,11 @@ const MainPage = () => {
     <div className="flex flex-col gap-6 p-6 pb-30">
       <Header />
       <ProfileCard
-        profileImgUrl={dashboardData.profileImgUrl}
-        nickname={dashboardData.nickname}
-        statusMessage={dashboardData.statusMessage}
-        problemSetId={dashboardData.todayProblemSetId}
+        profileImgUrl={userProfileData.profileImageUrl}
+        nickname={userProfileData.nickname}
+        statusMessage={userProfileData.statusMessage}
       />
-      <TotalStudyCard studyStats={dashboardData.studyStats} />
+      <TotalStudyCard studyStats={userStudyStatData.studyStats} />
       <ChunsikCard />
       <BottomNav />
     </div>

--- a/koco/src/pages/SurveyPage/index.tsx
+++ b/koco/src/pages/SurveyPage/index.tsx
@@ -29,14 +29,12 @@ export interface IProblemSetResponse {
 
 const SurveyPage = () => {
   const location = useLocation();
-  const problemSetId = Number(location.state?.problemSetId);
-  const targetDate = location.state?.date;
 
+  const targetDate = location.state?.date;
   const navigate = useNavigate();
   const [surveyData, setSurveyData] = useState<ISurveyData[]>([]);
   const registerSurveyMutation = useRegisterSurvey();
   const { data: problemListData, error } = useProblemSet(targetDate);
-
   const allAnswered = surveyData.every(
     item => item.isSolved !== null && item.difficultyLevel !== ''
   );
@@ -53,8 +51,14 @@ const SurveyPage = () => {
 
   // api를 호출해 설문 데이터를 전송합니다
   const handleSubmitSurvey = () => {
+    if (!problemListData?.problemSetId) {
+      return;
+    }
+
+    console.log(problemListData?.problemSetId);
+
     const requestData: IProblemSurveyRequest = {
-      problemSetId: problemSetId,
+      problemSetId: problemListData.problemSetId,
       responses: surveyData.map(item => ({
         problemId: item.problemId,
         //problemNumber: index + 1,


### PR DESCRIPTION
# TITLE
[FEATURE] 메인 페이지 - 유저 프로필 조회, 알고리즘 스탯 조회 API 연결 (#69)

## 📝 개요
기존의 대시보드 API에서 분리된 유저 프로필 조회, 알고리즘 스탯 조회 API를 연결합니다.

## 🔗 연관된 이슈
closes #69 

## 🔄 변경사항 및 이유
- API 호출을 위한 useQuery custom 훅 생성 (useUserProfile, useUserStats)

## 📋 작업할 내용
- [x] 유저 프로필
- [x] 알고리즘 스탯

## 🔖 기타사항


## 👀 리뷰 요구사항 (선택)
- 리뷰어에게 특별히 확인받고 싶은 부분이 있으면 작성


## 🔗 참고 자료 (선택)
- 관련 문서나 링크가 있으면 첨부
