### PR TITLE
[BUG] 문제 요약 부분 줄바꿈이 이상한 문제 (#86)

### DIFF
--- a/koco/src/pages/ProblemSolutionPage/components/ProblemSolutionSection/index.tsx
+++ b/koco/src/pages/ProblemSolutionPage/components/ProblemSolutionSection/index.tsx
@@ -14,13 +14,13 @@ const formatCode = (code: string | undefined) => {
   return code.replace(/\\n/g, '\n');
 };
 
-// problemSolving 전용 포맷 함수
+/// problemSolving 전용 포맷 함수
 const formatProblemSolving = (text: string | undefined) => {
   if (!text) return '';
 
   return text
     .replace(/\\n/g, '\n') // 문자열 내 \n 처리
-    .replace(/([^\n])(\d+\.\s)/g, '$1\n$2'); // 번호 앞에 줄바꿈 추가
+    .replace(/다\./g, '다.\n'); // '다.'로 끝나는 문장 뒤에 줄바꿈 추가
 };
 
 const ProblemSolutionSection = ({


### PR DESCRIPTION
# TITLE
[BUG] 문제 요약 부분 줄바꿈이 이상한 문제 (#86)

## 📝 개요
문제 해설 페이지의 문제 요약 부분(problemSolving)의 파싱이 적절하지 못한 부분을 수정하였습니다.

## 🔗 연관된 이슈
- closes #86

## 🔄 변경사항 및 이유
- '숫자.' 형태를 정규 표현식으로 검사해 줄바꿈을 하던 기존 로직을 '다.'를 검사하여 줄바꿈하는 것으로 수정하였습니다.

## 📋 작업할 내용
- [x] formatProblemSolving 유틸 함수 수정

## 🔖 기타사항

## 👀 리뷰 요구사항 (선택)


## 🔗 참고 자료 (선택)
