### PR TITLE
[FEATURE] 수식 데이터 전처리 로직 구현 (#81)

### DIFF
--- a/koco/package-lock.json
+++ b/koco/package-lock.json
@@ -12,6 +12,7 @@
         "@tanstack/react-query": "^5.75.0",
         "@tanstack/react-query-devtools": "^5.75.0",
         "axios": "^1.9.0",
+        "better-react-mathjax": "^2.3.0",
         "chart.js": "^4.4.9",
         "react": "^19.0.0",
         "react-chartjs-2": "^5.3.0",
@@ -1736,6 +1737,14 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.8.tgz",
+      "integrity": "sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
@@ -1977,6 +1986,17 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/better-react-mathjax": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/better-react-mathjax/-/better-react-mathjax-2.3.0.tgz",
+      "integrity": "sha512-K0ceQC+jQmB+NLDogO5HCpqmYf18AU2FxDbLdduYgkHYWZApFggkHE4dIaXCV1NqeoscESYXXo1GSkY6fA295w==",
+      "dependencies": {
+        "mathjax-full": "^3.2.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2160,6 +2180,14 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/concat-map": {
@@ -2816,6 +2844,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/espree": {
@@ -4177,6 +4213,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mathjax-full": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.2.2.tgz",
+      "integrity": "sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==",
+      "dependencies": {
+        "esm": "^3.2.25",
+        "mhchemparser": "^4.1.0",
+        "mj-context-menu": "^0.6.1",
+        "speech-rule-engine": "^4.0.6"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4185,6 +4232,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/mhchemparser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/mhchemparser/-/mhchemparser-4.2.1.tgz",
+      "integrity": "sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ=="
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -4229,6 +4281,11 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/mj-context-menu": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.6.1.tgz",
+      "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA=="
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -5071,6 +5128,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/speech-rule-engine": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.1.2.tgz",
+      "integrity": "sha512-S6ji+flMEga+1QU79NDbwZ8Ivf0S/MpupQQiIC0rTpU/ZTKgcajijJJb1OcByBQDjrXCN1/DJtGz4ZJeBMPGJw==",
+      "dependencies": {
+        "@xmldom/xmldom": "0.9.8",
+        "commander": "13.1.0",
+        "wicked-good-xpath": "1.3.0"
+      },
+      "bin": {
+        "sre": "bin/sre"
+      }
+    },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
@@ -5724,6 +5794,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/wicked-good-xpath": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
+      "integrity": "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw=="
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",

--- a/koco/package.json
+++ b/koco/package.json
@@ -14,6 +14,7 @@
     "@tanstack/react-query": "^5.75.0",
     "@tanstack/react-query-devtools": "^5.75.0",
     "axios": "^1.9.0",
+    "better-react-mathjax": "^2.3.0",
     "chart.js": "^4.4.9",
     "react": "^19.0.0",
     "react-chartjs-2": "^5.3.0",

--- a/koco/src/main.tsx
+++ b/koco/src/main.tsx
@@ -1,8 +1,14 @@
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 
+// MathJax 설정
+// const config = {
+//   tex: { inlineMath: [['$', '$']] },
+// };
+
 createRoot(document.getElementById('root')!).render(
   //<StrictMode>
+  //<MathJaxContext config={config}>
   <App />
   //</StrictMode>
 );

--- a/koco/src/pages/ProblemSolutionPage/components/ProblemDetailSection/index.tsx
+++ b/koco/src/pages/ProblemSolutionPage/components/ProblemDetailSection/index.tsx
@@ -1,83 +1,99 @@
 import { IGetProblemSolutionResponse } from '@/apis/problemApi';
+import { processMathText } from '@/utils/converter/processMathText';
+import { MathJax, MathJaxContext } from 'better-react-mathjax';
 
 const ProblemDetailSection = (data: IGetProblemSolutionResponse) => {
-  console.log(data?.inputExample);
-  console.log(data?.outputExample);
+  // 수식 적용 위한 설정
+  const config = {
+    tex: {
+      inlineMath: [['$', '$']], // 인라인 수학 표현식을 구분하는 기호를 정의
+    },
+    options: {
+      renderActions: {
+        addMenu: [], // UI에서 보여지는 컨텍스트 메뉴 제거
+        checkLoading: [],
+      },
+    },
+  };
+
+  console.log(processMathText(data.inputDescription));
 
   return (
-    <section className="p-6 sh bg-surface">
-      {/* 문제 제목 */}
+    <MathJaxContext config={config}>
+      <section className="p-6 sh bg-surface">
+        {/* 문제 제목 */}
 
-      <div className="flex justify-between mb-2">
-        <h1 className="text-xl font-bold">
-          {data?.problemNumber}번 {data.title}
-        </h1>
-        {data.bojUrl && (
-          <a
-            href={data.bojUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="py-2 px-3 bg-secondary text-white rounded-md hover:bg-secondary-hover transition-colors text-sm font-medium"
-          >
-            백준 문제 바로가기 →
-          </a>
-        )}
-      </div>
-
-      {/* 제한 조건 테이블 */}
-      <table className="w-full mt-4 mb-6 text-sm border border-border">
-        <thead className="bg-gray-100">
-          <tr>
-            <th className="border-border px-3 py-2">시간 제한</th>
-            <th className="border-border px-3 py-2">메모리 제한</th>
-            <th className="border-border px-3 py-2">제출</th>
-            <th className="border-border px-3 py-2">정답</th>
-            <th className="border-border px-3 py-2">맞힌 사람</th>
-            <th className="border-border px-3 py-2">정답 비율</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr className="text-center">
-            <td className="border-border px-3 py-2">{data.timeLimit}</td>
-            <td className="border-border px-3 py-2">{data.memoryLimit} MB</td>
-            <td className="border-border px-3 py-2">{data.submissionCnt}</td>
-            <td className="border-border px-3 py-2">{data.answerCnt}</td>
-            <td className="border-border px-3 py-2">{data.answerCnt}</td>
-            <td className="border-border px-3 py-2">{data.correctPplCnt}</td>
-          </tr>
-        </tbody>
-      </table>
-
-      {/* 문제 설명 */}
-      <div className="mb-6 text-sm leading-relaxed text-gray-800">
-        <h2 className="font-semibold text-base mb-2">문제</h2>
-        <p>{data.description}</p>
-      </div>
-
-      {/* 입력 */}
-      <div className="mb-6 text-sm leading-relaxed text-gray-800">
-        <h2 className="font-semibold text-base mb-2">입력</h2>
-        <p>{data.inputDescription}</p>
-      </div>
-
-      {/* 출력 */}
-      <div className="mb-6 text-sm leading-relaxed text-gray-800">
-        <h2 className="font-semibold text-base mb-2">출력</h2>
-        <p>{data.outputDescription}</p>
-      </div>
-
-      {/* 예시 */}
-      <div className="grid grid-cols-2 gap-4 text-sm">
-        <div>
-          <h3 className="font-semibold mb-1">예시 입력</h3>
-          <pre className="bg-gray-100 p-3 rounded whitespace-pre-line">{data.inputExample}</pre>
+        <div className="flex justify-between mb-2">
+          <h1 className="text-xl font-bold">
+            {data?.problemNumber}번 {data.title}
+          </h1>
+          {data.bojUrl && (
+            <a
+              href={data.bojUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="py-2 px-3 bg-secondary text-white rounded-md hover:bg-secondary-hover transition-colors text-sm font-medium"
+            >
+              백준 문제 바로가기 →
+            </a>
+          )}
         </div>
-        <div>
-          <h3 className="font-semibold mb-1">예시 출력</h3>
-          <pre className="bg-gray-100 p-3 rounded whitespace-pre-line">{data.outputExample}</pre>
+
+        {/* 제한 조건 테이블 */}
+        <table className="w-full mt-4 mb-6 text-sm border border-border">
+          <thead className="bg-gray-100">
+            <tr>
+              <th className="border-border px-3 py-2">시간 제한</th>
+              <th className="border-border px-3 py-2">메모리 제한</th>
+              <th className="border-border px-3 py-2">제출</th>
+              <th className="border-border px-3 py-2">정답</th>
+              <th className="border-border px-3 py-2">맞힌 사람</th>
+              <th className="border-border px-3 py-2">정답 비율</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr className="text-center">
+              <td className="border-border px-3 py-2">{data.timeLimit}</td>
+              <td className="border-border px-3 py-2">{data.memoryLimit} MB</td>
+              <td className="border-border px-3 py-2">{data.submissionCnt}</td>
+              <td className="border-border px-3 py-2">{data.answerCnt}</td>
+              <td className="border-border px-3 py-2">{data.answerCnt}</td>
+              <td className="border-border px-3 py-2">{data.correctPplCnt}</td>
+            </tr>
+          </tbody>
+        </table>
+
+        {/* 문제 설명 */}
+        <div className="mb-6 text-sm leading-relaxed text-gray-800">
+          <h2 className="font-semibold text-base mb-2">문제</h2>
+          <p>{processMathText(data.description)}</p>
         </div>
-      </div>
-    </section>
+
+        {/* 입력 */}
+        <div className="mb-6 text-sm leading-relaxed text-gray-800">
+          <h2 className="font-semibold text-base mb-2">입력</h2>
+          <MathJax> {processMathText(data.inputDescription)}</MathJax>
+        </div>
+
+        {/* 출력 */}
+        <div className="mb-6 text-sm leading-relaxed text-gray-800">
+          <h2 className="font-semibold text-base mb-2">출력</h2>
+          <MathJax> {processMathText(data.outputDescription)}</MathJax>
+        </div>
+
+        {/* 예시 */}
+        <div className="grid grid-cols-2 gap-4 text-sm">
+          <div>
+            <h3 className="font-semibold mb-1">예시 입력</h3>
+            <pre className="bg-gray-100 p-3 rounded whitespace-pre-line">{data.inputExample}</pre>
+          </div>
+          <div>
+            <h3 className="font-semibold mb-1">예시 출력</h3>
+            <pre className="bg-gray-100 p-3 rounded whitespace-pre-line">{data.outputExample}</pre>
+          </div>
+        </div>
+      </section>
+    </MathJaxContext>
   );
 };
 

--- a/koco/src/styles/global.css
+++ b/koco/src/styles/global.css
@@ -52,3 +52,47 @@ svg {
   display: block;
   max-width: 100%;
 }
+
+/* math-styles.css - 이 파일을 생성하고 전역 스타일에 import하거나 직접 global.css에 추가 */
+
+/* MathJax 미리보기 숨김 (중복 방지) */
+.MathJax_Preview {
+  display: none !important;
+}
+
+/* 수식 컨테이너 스타일 */
+.math-content {
+  width: 100%;
+  overflow: visible;
+  line-height: 1.5;
+}
+
+/* 줄바꿈 보존 */
+.math-content .math-line {
+  margin: 0.5em 0;
+  padding: 0;
+}
+
+/* 첫번째 줄은 위 마진 제거 */
+.math-content .math-line:first-child {
+  margin-top: 0;
+}
+
+/* 마지막 줄은 아래 마진 제거 */
+.math-content .math-line:last-child {
+  margin-bottom: 0;
+}
+
+.MathJax {
+  overflow-x: auto;
+  overflow-y: hidden;
+  max-width: 100%;
+}
+
+/* MathJax 컨테이너 스타일 조정 */
+mjx-container {
+  display: inline-block !important;
+  white-space: normal !important;
+  overflow-wrap: break-word !important;
+  word-wrap: break-word !important;
+}

--- a/koco/src/utils/converter/processMathText.ts
+++ b/koco/src/utils/converter/processMathText.ts
@@ -1,0 +1,15 @@
+/**
+ * 수식 앞쪽의 문자열을 처리하는 함수
+ * 수식 부분($...$)은 그대로 남기고, 수식 바로 앞의 텍스트는 공백 전까지 지웁니다.
+ *
+ * @param {string} text - 처리할 텍스트
+ * @returns {string} - 처리된 텍스트
+ */
+// 수식 처리 함수
+export const processMathText = (text: string) => {
+  // 비공백 문자들(최소 탐욕적) + $ + 수식 내용 + $ 패턴을 찾음
+  return text.replace(/(\S+?)(\$[^$]*?(?:\\\\\\$[^$]*?)*?\$)/g, (match, prefix, formula) => {
+    // prefix는 수식 바로 앞의 단어, formula는 수식 부분
+    return formula;
+  });
+};

--- a/koco/src/vite-env.d.ts
+++ b/koco/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+// MathJax 타입 선언
+declare global {
+  // eslint-disable-next-line
+  interface Window {
+    // eslint-disable-next-line
+    MathJax: any;
+  }
+}


### PR DESCRIPTION
# [FEATURE] 수식 데이터 전처리 로직 구현 (#81 )

## 📝 개요
- 수식 렌더링을 위한 데이터 전처리 함수 `processMathText` 구현
- `better-react-mathjax`를 사용해 수식 렌더링 처리

## 🔗 연관된 이슈
closes #81 

## 🔄 변경사항 및 이유
DB 상의 데이터에 텍스트와 수식 데이터가 중복으로 포함되어 저장되었습니다. (예: N-1$N-1$ -> $N-1$ 이 되어야 함)

따라서 `$...$` 수식 표현을 기준으로, 앞에 붙은 중복 텍스트를 제거하는 `processMathText` 함수를 구현하였습니다.

잘못된 데이터를 클린하게 정제한 후 `better-react-mathjax`를 통해 수식을 정상적으로 렌더링 하였습니다.

## 📋 작업할 내용
- [x] 수식 전처리 함수 (processMathText) 구현
- [x] 수식 렌더링을 위한 라이브러리 적용 (better-react-mathjax)

## 🔖 기타사항
- 외부 라이브러리 사용 (better-react-mathjax)
- 문제 데이터의 경우 추후 HTML을 그대로 렌더링 하는 것으로 변경될 예정
- 수식 렌더링 성능 고려 필요

## 👀 리뷰 요구사항 (선택)

## 🔗 참고 자료 (선택)
[better-react-mathjax GitHub](https://github.com/fast-reflexes/better-react-mathjax)