### PR TITLE
[FEATURE] 예시 입력, 예시 출력이 여러개일 경우 구분 출력 (#88)

### DIFF
--- a/koco/src/pages/ProblemSolutionPage/components/ProblemDetailSection/index.tsx
+++ b/koco/src/pages/ProblemSolutionPage/components/ProblemDetailSection/index.tsx
@@ -93,8 +93,8 @@ const ProblemDetailSection = (data: IGetProblemSolutionResponse) => {
 
         <div className="space-y-4 text-sm">
           {inputBlocks.map((input, index) => (
-            <>
-              <div key={`example-${index}`} className="grid grid-cols-2 gap-4">
+            <React.Fragment key={`example-${index}`}>
+              <div className="grid grid-cols-2 gap-4">
                 <div>
                   <h3 className="font-semibold mb-1">예제 입력 {index + 1}</h3>
                   <pre className="bg-gray-100 p-3 rounded whitespace-pre-line">{input}</pre>

--- a/koco/src/pages/ProblemSolutionPage/components/ProblemDetailSection/index.tsx
+++ b/koco/src/pages/ProblemSolutionPage/components/ProblemDetailSection/index.tsx
@@ -16,7 +16,15 @@ const ProblemDetailSection = (data: IGetProblemSolutionResponse) => {
     },
   };
 
-  console.log(processMathText(data.inputDescription));
+  const processText = (text: string) => {
+    if (!text) return [];
+
+    // Split text by double line breaks
+    return text.split(/\n\s*\n/).filter(block => block.trim() !== '');
+  };
+
+  const inputBlocks = processText(data.inputExample);
+  const outputBlocks = processText(data.outputExample);
 
   return (
     <MathJaxContext config={config}>
@@ -82,15 +90,24 @@ const ProblemDetailSection = (data: IGetProblemSolutionResponse) => {
         </div>
 
         {/* 예시 */}
-        <div className="grid grid-cols-2 gap-4 text-sm">
-          <div>
-            <h3 className="font-semibold mb-1">예시 입력</h3>
-            <pre className="bg-gray-100 p-3 rounded whitespace-pre-line">{data.inputExample}</pre>
-          </div>
-          <div>
-            <h3 className="font-semibold mb-1">예시 출력</h3>
-            <pre className="bg-gray-100 p-3 rounded whitespace-pre-line">{data.outputExample}</pre>
-          </div>
+
+        <div className="space-y-4 text-sm">
+          {inputBlocks.map((input, index) => (
+            <>
+              <div key={`example-${index}`} className="grid grid-cols-2 gap-4">
+                <div>
+                  <h3 className="font-semibold mb-1">예제 입력 {index + 1}</h3>
+                  <pre className="bg-gray-100 p-3 rounded whitespace-pre-line">{input}</pre>
+                </div>
+                <div>
+                  <h3 className="font-semibold mb-1">예제 출력 {index + 1}</h3>
+                  <pre className="bg-gray-100 p-3 rounded whitespace-pre-line ">
+                    {outputBlocks[index] ?? ''}
+                  </pre>
+                </div>
+              </div>
+            </>
+          ))}
         </div>
       </section>
     </MathJaxContext>


### PR DESCRIPTION
# TITLE
[FEATURE] 예시 입력, 예시 출력이 여러개일 경우 구분 출력 (#88)

## 📝 개요
기존의 예시 입력/예시 출력 데이터는 두 줄씩 띄어져 있어 구분이 가능했으나 UI상으로는 하나의 블록으로 합쳐져 있었습니다.
이를 구분하여 출력하고,  예시 입,출력이 여러 세트일 경우 이를 구분하여 보여줍니다.

## 🔗 연관된 이슈
- closes #88 

## 🔄 변경사항 및 이유
- `processText` 함수 구현: 예시 입,출력 데이터에서 두 줄을 띄는 개행 문자가 있을 시, 이를 기반으로 나누어 배열로 리턴하는 함수입니다.
- 예시 입,출력 데이터를 하나의 div 안에 위치하여 첫 번째 예시-첫 번째 출력을 grid로 묶어 함께 보여지도록 수정하였습니다.

## 📋 작업할 내용
- [x] 예시 데이터를 나누는 로직 구현
- [x] UI 상으로 첫 번째 예시-첫 번째 출력과 함께 보여지도록 수정 

## 🔖 기타사항
- [x] ProblemDetailSection 리팩토링 필요

## 👀 리뷰 요구사항 (선택)

## 🔗 참고 자료 (선택)
