### PR TITLE
[FEATURE] 유저 프로필 이미지 S3 업로드 연동 (#84)

### DIFF
--- a/koco/src/@types/image/index.ts
+++ b/koco/src/@types/image/index.ts
@@ -1,0 +1,9 @@
+export interface IProfileImageResponse {
+  fileUrl: string;
+  presignedUrl: string;
+}
+
+export interface IS3UploadRequest {
+  presignedUrl: string;
+  file: File;
+}

--- a/koco/src/@types/user/index.ts
+++ b/koco/src/@types/user/index.ts
@@ -30,3 +30,9 @@ export interface IStudyStat {
 export interface IStudyStatsResponse {
   studyStats: IStudyStat[];
 }
+
+export interface ICompleteUserProfileRequest {
+  nickname: string;
+  profileImg: string;
+  statusMsg: string;
+}

--- a/koco/src/@types/user/index.ts
+++ b/koco/src/@types/user/index.ts
@@ -33,6 +33,6 @@ export interface IStudyStatsResponse {
 
 export interface ICompleteUserProfileRequest {
   nickname: string;
-  profileImg: string;
+  profileImgUrl: string;
   statusMsg: string;
 }

--- a/koco/src/apis/axios/index.ts
+++ b/koco/src/apis/axios/index.ts
@@ -29,19 +29,13 @@ const refreshToken = async () => {
   }
 };
 
-// 요청 인터셉터 - 로깅 및 요청 전 추가 처리
-axiosInstance.interceptors.request.use(
-  config => {
-    // 파일을 포함한 요청인 경우 자동으로 'Content-Type'을 설정하지 않음
-    if (config.data instanceof FormData) {
-      // FormData는 axios가 자동으로 처리하도록 설정
-      delete config.headers['Content-Type']; // 'Content-Type' 헤더를 제거
-    }
-
-    return config;
-  },
-  error => Promise.reject(error)
-);
+// // 요청 인터셉터 - 로깅 및 요청 전 추가 처리
+// axiosInstance.interceptors.request.use(
+//   config => {
+//     return config;
+//   },
+//   error => Promise.reject(error)
+// );
 
 // 응답 인터셉터
 axiosInstance.interceptors.response.use(
@@ -71,7 +65,7 @@ axiosInstance.interceptors.response.use(
       }
     }
 
-    // 500 에러 처리 - 서버 에러 로깅 및 사용자 알림
+    // 500 에러 처리
     if (error.response?.status === 500) {
       return Promise.reject(error);
     }

--- a/koco/src/apis/imageApi.ts
+++ b/koco/src/apis/imageApi.ts
@@ -1,0 +1,31 @@
+import axios from './axios';
+import { IApiResponse } from '@/@types/api';
+import { IProfileImageResponse, IS3UploadRequest } from '@/@types/image';
+
+const V1_SUB_URL = '/api/backend/v1';
+
+/**
+ * GET) 사용자 프로필 업로드를 위한 presigned url 요청
+ * @QueryParam
+ * @return fileUrl, presignedUrl
+ */
+export const getPresignedUrl = async (fileName: string) => {
+  const response = await axios.get<IApiResponse<IProfileImageResponse>>(
+    `${V1_SUB_URL}/upload/presigned-url?fileName=${fileName}`
+  );
+
+  return response.data.data;
+};
+
+/**
+ * PUT) S3 이미지 업로드
+ * @body file
+ */
+export const uploadToS3 = async (data: IS3UploadRequest) => {
+  const response = await axios.put(data.presignedUrl, data.file, {
+    headers: { 'Content-Type': data.file.type },
+    withCredentials: false,
+  });
+
+  return response.status === 200;
+};

--- a/koco/src/apis/userApi.ts
+++ b/koco/src/apis/userApi.ts
@@ -20,12 +20,8 @@ export interface ICompleteProfileRequest {
   statusMsg: string;
 }
 
-export const completeProfile = async (formData: FormData) => {
-  const response = await axios.post<IApiResponse<null>>(`${V1_SUB_URL}/me`, formData, {
-    headers: {
-      'Content-Type': 'multipart/form-data',
-    },
-  });
+export const completeProfile = async (profileData: ICompleteProfileRequest) => {
+  const response = await axios.post<IApiResponse<null>>(`${V1_SUB_URL}/me`, profileData);
 
   return response.data.data;
 };

--- a/koco/src/apis/userApi.ts
+++ b/koco/src/apis/userApi.ts
@@ -16,7 +16,7 @@ const V1_SUB_URL = '/api/backend/v1/users';
 
 export interface ICompleteProfileRequest {
   nickname: string;
-  profileImg: string;
+  profileImgUrl: string;
   statusMsg: string;
 }
 

--- a/koco/src/hooks/mutations/useImageMutations.ts
+++ b/koco/src/hooks/mutations/useImageMutations.ts
@@ -1,0 +1,12 @@
+import { IS3UploadRequest } from '@/@types/image';
+import { uploadToS3 } from '@/apis/imageApi';
+import { useMutation } from '@tanstack/react-query';
+
+export const useUploadS3 = () => {
+  return useMutation({
+    mutationFn: (data: IS3UploadRequest) => uploadToS3(data),
+    onSuccess: () => {
+      // 성공 시 관련 쿼리 무효화
+    },
+  });
+};

--- a/koco/src/hooks/mutations/useUserMutations.ts
+++ b/koco/src/hooks/mutations/useUserMutations.ts
@@ -1,6 +1,7 @@
 // src/hooks/mutations/useUserMutations.ts
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { completeProfile, deleteUser } from '@/apis/userApi';
+import { ICompleteUserProfileRequest } from '@/@types/user';
 
 /**
  * 사용자 프로필 완성 뮤테이션 훅
@@ -9,7 +10,7 @@ export const useCompleteProfile = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: FormData) => completeProfile(data),
+    mutationFn: (data: ICompleteUserProfileRequest) => completeProfile(data),
     onSuccess: () => {
       // 성공 시 관련 쿼리 무효화
       queryClient.invalidateQueries({ queryKey: ['complete-profile'] });

--- a/koco/src/hooks/queries/queryKeys.ts
+++ b/koco/src/hooks/queries/queryKeys.ts
@@ -3,6 +3,7 @@ export const queryKeys = {
     all: ['users'] as const,
     stats: ['users', 'stats'] as const,
     profile: ['users', 'profile'] as const,
+    presignedUrl: ['users', 'profile', 'presigned-url'] as const,
   },
 
   problems: {

--- a/koco/src/hooks/queries/useImageQueries.ts
+++ b/koco/src/hooks/queries/useImageQueries.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from './queryKeys';
+import { getPresignedUrl } from '@/apis/imageApi';
+
+/**
+ * 사용자 프로필 업로드를 위한 presigned url 요청
+ */
+export const useGetPresignedUrl = (fileName: string) => {
+  return useQuery({
+    queryKey: queryKeys.users.presignedUrl,
+    queryFn: () => getPresignedUrl(fileName),
+    staleTime: 1000 * 60 * 5,
+    enabled: !!fileName,
+  });
+};

--- a/koco/src/pages/FirstLoginPage/index.tsx
+++ b/koco/src/pages/FirstLoginPage/index.tsx
@@ -1,4 +1,4 @@
-import { useRef, useMemo } from 'react';
+import { useRef, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import DEFAULT_IMG from '@/assets/defaultProfileImage.svg';
 import useInput from '@/hooks/custom/useInput';
@@ -6,7 +6,7 @@ import useFileInput from '@/hooks/custom/useFileInput';
 import Button from '@/components/ui/Button';
 import { useCompleteProfile } from '@/hooks/mutations/useUserMutations';
 import { useUploadS3 } from '@/hooks/mutations/useImageMutations';
-import { useGetPresignedUrl } from '@/hooks/queries/useImageQueries';
+import { getPresignedUrl } from '@/apis/imageApi';
 
 export default function FirstLoginPage() {
   const fileRef = useRef<HTMLInputElement | null>(null);
@@ -15,10 +15,12 @@ export default function FirstLoginPage() {
   const { value: nickname, onChange: onChangeNickname } = useInput();
   const { value: statusMsg, onChange: onChangeStatusMessage } = useInput();
   const { preview, onChange: onChangeFile } = useFileInput();
-  const { data: presignedData } = useGetPresignedUrl(fileRef.current?.files?.[0]?.name || '');
+  //const { data: presignedData } = useGetPresignedUrl(fileRef.current?.files?.[0]?.name || '');
 
   const completeProfileMutation = useCompleteProfile();
   const s3UploadMutation = useUploadS3();
+
+  const [isLoading, setIsLoading] = useState(false);
   /* 유효성 검사 로직 */
   const nicknameErr = useMemo(() => {
     if (!nickname) return '닉네임을 입력해주세요.';
@@ -34,52 +36,53 @@ export default function FirstLoginPage() {
   const canSubmit = !nicknameErr && !statusErr && nickname;
 
   /* 제출 */
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!canSubmit) return;
 
-    // S3 업로드 로직
-    if (presignedData && fileRef.current?.files?.[0]) {
-      // 파일이 있는 경우에만 S3 업로드 후 프로필 완성 API 호출
-      s3UploadMutation.mutate(
-        {
-          presignedUrl: presignedData.presignedUrl,
-          file: fileRef.current.files[0],
-        },
-        {
-          onSuccess: () => {
-            // S3 업로드 성공 후 프로필 완성 API 호출
-            const profileData = {
-              profileImg: presignedData?.fileUrl || '',
-              nickname: nickname,
-              statusMsg: statusMsg || '',
-            };
+    const file = fileRef.current?.files?.[0];
 
-            completeProfileMutation.mutate(profileData, {
-              onSuccess: () => {
-                //navigate('/home');
-                console.log('프로필 완성 성공, 홈 화면으로 돌아감');
-              },
+    try {
+      setIsLoading(true);
+
+      // S3 업로드 로직
+      let profileImgUrl = '';
+
+      if (file) {
+        // 파일이 있는 경우에만 S3 업로드 후 프로필 완성 API 호출
+
+        const presignedData = await getPresignedUrl(file.name);
+
+        if (presignedData) {
+          try {
+            await s3UploadMutation.mutateAsync({
+              presignedUrl: presignedData.presignedUrl,
+              file: file,
             });
-          },
-          onError: error => {
+
+            // 업로드 성공 시 URL 저장
+            profileImgUrl = presignedData.fileUrl;
+          } catch (error) {
             console.error('S3 업로드 실패:', error);
             alert('이미지 업로드에 실패했습니다.');
-          },
+
+            return;
+          }
         }
-      );
-    } else {
+      }
+
       // 파일이 없는 경우 바로 프로필 완성 API 호출
       const profileData = {
-        profileImg: '',
+        profileImgUrl: profileImgUrl,
         nickname: nickname,
         statusMsg: statusMsg || '',
       };
 
-      completeProfileMutation.mutate(profileData, {
-        onSuccess: () => {
-          navigate('/home');
-        },
-      });
+      await completeProfileMutation.mutateAsync(profileData);
+      navigate('/home');
+    } catch {
+      alert('프로필 등록에 실패했습니다. 다시 시도해주세요.');
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -133,12 +136,12 @@ export default function FirstLoginPage() {
 
       {/* 가입 버튼 */}
       <Button
-        disabled={!canSubmit}
+        disabled={!canSubmit || isLoading}
         onClick={handleSubmit}
         className={`mt-14 w-40 py-3 rounded-md text-white text-sm
-          ${canSubmit ? 'bg-primary hover:brightness-90' : 'bg-primary-disabled cursor-not-allowed'}`}
+           ${!canSubmit || isLoading ? 'bg-primary-disabled cursor-not-allowed' : 'bg-primary hover:brightness-90'}`}
       >
-        가입하기
+        {isLoading ? '처리중입니다...' : '가입하기'}
       </Button>
     </div>
   );

--- a/koco/src/pages/ProblemSolutionPage/components/ProblemDetailSection/index.tsx
+++ b/koco/src/pages/ProblemSolutionPage/components/ProblemDetailSection/index.tsx
@@ -1,6 +1,7 @@
 import { IGetProblemSolutionResponse } from '@/apis/problemApi';
 import { processMathText } from '@/utils/converter/processMathText';
 import { MathJax, MathJaxContext } from 'better-react-mathjax';
+import { Fragment } from 'react/jsx-runtime';
 
 const ProblemDetailSection = (data: IGetProblemSolutionResponse) => {
   // 수식 적용 위한 설정
@@ -93,7 +94,7 @@ const ProblemDetailSection = (data: IGetProblemSolutionResponse) => {
 
         <div className="space-y-4 text-sm">
           {inputBlocks.map((input, index) => (
-            <React.Fragment key={`example-${index}`}>
+            <Fragment key={`example-${index}`}>
               <div className="grid grid-cols-2 gap-4">
                 <div>
                   <h3 className="font-semibold mb-1">예제 입력 {index + 1}</h3>
@@ -106,7 +107,7 @@ const ProblemDetailSection = (data: IGetProblemSolutionResponse) => {
                   </pre>
                 </div>
               </div>
-            </>
+            </Fragment>
           ))}
         </div>
       </section>


### PR DESCRIPTION
# TITLE
[FEATURE] 유저 프로필 이미지 S3 업로드 연동 (#84)

## 📝 개요
이전의 프론트 -> 백엔드로 이미지를 전송해 S3에 연동하는 방법 대신 백엔드로부터 presigned url을 받아
프론트에서 s3에 이미지를 업로드 하는 로직으로 변경하였습니다.

## 🔗 연관된 이슈
- closes #84 

## 🔄 변경사항 및 이유
- `getPresignedUrl` : 백엔드로부터 presigned url과 fileUrl을 받기 위해 호출하는 함수
- `uploadToS3` : presigned url로 파일 업로드를 요청하는 함수
- 변경된 흐름
1. 사용자가 이미지를 업로드하고 '가입하기' 버튼 클릭 시 `getPresignedUrl` 호출, `fileUrl`과 `presignedUrl`을 받습니다.
2. `presignedUrl`로 사용자가 업로드한 파일을 업로드하는 put 요청을 합니다.
3. 성공적으로 업로드 시, `fileUrl`, `nickname`, `statusMsg` 데이터를 request body에 실어서 `completeProfile`을 호출합니다.

 (모든 api 호출 함수(getPresignedUrl 등)는 query, mutation 훅을 통해 래핑됩니다.)


## 📋 작업한 내용
- [x] presigned url 요청하는 api 함수 및 query 구현
- [x] presigned url 기반으로 파일 업로드하는 api 함수 및 mutation 구현
- [X] S3 버킷 CORS 설정
- [x] 파일 업로드 후 백엔드에 요청하는 로직 구현
- [x] 에러 처리
- [x] 로딩중 버튼 disabled 처리
- [x] 테스트
- [x] 불필요한 axios request interceptor 제거

## 🔖 기타사항
- [x] 백엔드 `postUserInfo` request param -> body로 변경 요청

## 👀 리뷰 요구사항 (선택)

## 🔗 참고 자료 (선택)

