### PR TITLE
[ENHANCEMENT] 문제 영역 html 렌더링 및 수식 데이터 포맷 처리 함수 구현 (#91)

### DIFF
--- a/koco/src/pages/ProblemSolutionPage/components/ProblemDetailSection/index.tsx
+++ b/koco/src/pages/ProblemSolutionPage/components/ProblemDetailSection/index.tsx
@@ -1,6 +1,8 @@
 import { IGetProblemSolutionResponse } from '@/apis/problemApi';
+import { processMathHtml } from '@/utils/converter/processMathHtml';
 import { processMathText } from '@/utils/converter/processMathText';
 import { MathJax, MathJaxContext } from 'better-react-mathjax';
+import { useEffect } from 'react';
 import { Fragment } from 'react/jsx-runtime';
 
 const ProblemDetailSection = (data: IGetProblemSolutionResponse) => {
@@ -17,15 +19,25 @@ const ProblemDetailSection = (data: IGetProblemSolutionResponse) => {
     },
   };
 
-  const processText = (text: string) => {
+  const divideExampleText = (text: string) => {
     if (!text) return [];
 
-    // Split text by double line breaks
+    // 두 줄 띄기를 기준으로 블록을 나누어 리턴
     return text.split(/\n\s*\n/).filter(block => block.trim() !== '');
   };
 
-  const inputBlocks = processText(data.inputExample);
-  const outputBlocks = processText(data.outputExample);
+  const inputBlocks = divideExampleText(data.inputExample);
+  const outputBlocks = divideExampleText(data.outputExample);
+  const cleanedHtml = processMathHtml(data.description);
+  useEffect(() => {
+    if (window.MathJax?.typesetPromise) {
+      window.MathJax?.typesetPromise();
+    }
+  }, [data]);
+
+  // useEffect(() => {
+  //   setCleanedHtml(processMathHtml(data.description));
+  // }, []);
 
   return (
     <MathJaxContext config={config}>
@@ -74,19 +86,24 @@ const ProblemDetailSection = (data: IGetProblemSolutionResponse) => {
 
         {/* 문제 설명 */}
         <div className="mb-6 text-sm leading-relaxed text-gray-800">
-          <h2 className="font-semibold text-base mb-2">문제</h2>
-          <p>{processMathText(data.description)}</p>
+          <h2 className="font-semibold text-xl mb-2">문제</h2>
+          <p>
+            <div
+              className="text-base leading-loose"
+              dangerouslySetInnerHTML={{ __html: cleanedHtml }}
+            />
+          </p>
         </div>
 
         {/* 입력 */}
         <div className="mb-6 text-sm leading-relaxed text-gray-800">
-          <h2 className="font-semibold text-base mb-2">입력</h2>
+          <h2 className="font-semibold text-xl mb-2">입력</h2>
           <MathJax> {processMathText(data.inputDescription)}</MathJax>
         </div>
 
         {/* 출력 */}
         <div className="mb-6 text-sm leading-relaxed text-gray-800">
-          <h2 className="font-semibold text-base mb-2">출력</h2>
+          <h2 className="font-semibold text-xl mb-2">출력</h2>
           <MathJax> {processMathText(data.outputDescription)}</MathJax>
         </div>
 
@@ -97,11 +114,11 @@ const ProblemDetailSection = (data: IGetProblemSolutionResponse) => {
             <Fragment key={`example-${index}`}>
               <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <h3 className="font-semibold mb-1">예제 입력 {index + 1}</h3>
+                  <h3 className="font-semibold text-base mb-1">예제 입력 {index + 1}</h3>
                   <pre className="bg-gray-100 p-3 rounded whitespace-pre-line">{input}</pre>
                 </div>
                 <div>
-                  <h3 className="font-semibold mb-1">예제 출력 {index + 1}</h3>
+                  <h3 className="font-semibold text-base mb-1">예제 출력 {index + 1}</h3>
                   <pre className="bg-gray-100 p-3 rounded whitespace-pre-line ">
                     {outputBlocks[index] ?? ''}
                   </pre>

--- a/koco/src/utils/converter/processMathHtml.ts
+++ b/koco/src/utils/converter/processMathHtml.ts
@@ -1,0 +1,19 @@
+/**
+ *
+ * @param html
+ * @returns processedHtml (중복 요소를 가공한 html)
+ */
+export const processMathHtml = (html: string) => {
+  if (!html) return '';
+
+  // LaTeX 수식 추출
+  const processedHtml = html.replace(
+    /<mjx-container[^>]*>[\s\S]*?<span aria-hidden="true" class="no-mathjax mjx-copytext">([\s\S]*?)<\/span><\/mjx-container>/g,
+    (match, latexContent) => {
+      // LaTeX 형식 그대로 유지
+      return latexContent;
+    }
+  );
+
+  return processedHtml;
+};

--- a/koco/src/vite-env.d.ts
+++ b/koco/src/vite-env.d.ts
@@ -1,9 +1,14 @@
 /// <reference types="vite/client" />
 // MathJax 타입 선언
+
+export {};
+
 declare global {
   // eslint-disable-next-line
   interface Window {
-    // eslint-disable-next-line
-    MathJax: any;
+    MathJax: {
+      typesetPromise?: (elements?: Array<HTMLElement | string>) => Promise<void>;
+      typeset?: (elements?: Array<HTMLElement | string>) => void;
+    };
   }
 }


### PR DESCRIPTION
# [FEATURE] 문제 영역 html 렌더링 및 수식 데이터 포맷 처리 함수 구현 (#91)

## 📝 개요
기존의 string 타입 데이터 렌더링 대신 html string을 렌더링하는 것으로 변경하였습니다.

## 🔗 연관된 이슈
- closes #91 

## 🔄 변경사항 및 이유
- 수식이 크롤링 과정에서 이중으로 처리되어, 이를 해결하기 위해 `processMathText` 함수를 구현하였습니다.
- 문제 해설 페이지의 글자 크기가 일관적이지 않았던 디자인을 수정하였습니다.

## 📋 작업할 내용
- [x] 수식 데이터 전처리 함수 구현
- [x] 새로 고침 시에만 수식이 적용되는 문제 해결 

## 🔖 기타사항

## 👀 리뷰 요구사항 (선택)

## 🔗 참고 자료 (선택)
- 관련 문서나 링크가 있으면 첨부
