### PR TITLE
[CHORE] MathJax 폰트 preload, resize 이벤트 적용, css 수정 (#111)

### DIFF
--- a/koco/index.html
+++ b/koco/index.html
@@ -16,6 +16,17 @@
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <title>KOCO</title>
+    <!-- HTML head에 MathJax 폰트 프리로드 추가 -->
+    <link
+      rel="preload"
+      href="https://cdn.jsdelivr.net/npm/mathjax@3/es5/output/svg/fonts/tex.js"
+      as="script"
+    />
+    <link
+      rel="preload"
+      href="https://cdn.jsdelivr.net/npm/mathjax@3/es5/output/svg/fonts/tex-script.js"
+      as="script"
+    />
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/orioncactus/Pretendard/dist/web/static/pretendard.css"

--- a/koco/src/pages/ProblemSolutionPage/components/ProblemDetailSection/index.tsx
+++ b/koco/src/pages/ProblemSolutionPage/components/ProblemDetailSection/index.tsx
@@ -29,15 +29,17 @@ const ProblemDetailSection = (data: IGetProblemSolutionResponse) => {
   const inputBlocks = divideExampleText(data.inputExample);
   const outputBlocks = divideExampleText(data.outputExample);
   const cleanedHtml = processMathHtml(data.description);
+
   useEffect(() => {
     if (window.MathJax?.typesetPromise) {
-      window.MathJax?.typesetPromise();
+      window.MathJax.typesetPromise().then(() => {
+        //MathJax 렌더링 완료 후 강제 리플로우
+        setTimeout(() => {
+          window.dispatchEvent(new Event('resize'));
+        }, 0);
+      });
     }
   }, [data]);
-
-  // useEffect(() => {
-  //   setCleanedHtml(processMathHtml(data.description));
-  // }, []);
 
   return (
     <MathJaxContext config={config}>

--- a/koco/src/styles/global.css
+++ b/koco/src/styles/global.css
@@ -95,4 +95,12 @@ mjx-container {
   white-space: normal !important;
   overflow-wrap: break-word !important;
   word-wrap: break-word !important;
+  position: static !important;
+}
+
+/* MathJax 관련 요소들의 position 초기화 */
+.MathJax,
+.MathJax_Display,
+.math-content {
+  position: static !important;
 }

--- a/koco/src/utils/converter/processMathHtml.ts
+++ b/koco/src/utils/converter/processMathHtml.ts
@@ -6,11 +6,10 @@
 export const processMathHtml = (html: string) => {
   if (!html) return '';
 
-  // LaTeX 수식 추출
+  // 수식 추출
   const processedHtml = html.replace(
     /<mjx-container[^>]*>[\s\S]*?<span aria-hidden="true" class="no-mathjax mjx-copytext">([\s\S]*?)<\/span><\/mjx-container>/g,
     (match, latexContent) => {
-      // LaTeX 형식 그대로 유지
       return latexContent;
     }
   );


### PR DESCRIPTION
# TITLE [CHORE] MathJax 폰트 preload, resize 이벤트 적용, css 수정 (#111 )

## 📝 개요


## 🔗 연관된 이슈
- #111 

## 🔄 변경사항 및 이유
- 수식에서 사용되는 폰트를 preload하도록 변경
- MathJax 렌더링 완료 후 강제 리플로우
- position: static으로 수정

## 📋 작업할 내용
- [x] 폰트 preload
- [x] MathJax 강제 리플로우 
- [x] css 수정

## 🔖 기타사항
- [ ] dev 서버 배포 후 수식 렌더링이 잘 보여지는지 확인 필요

## 👀 리뷰 요구사항 (선택)
- 리뷰어에게 특별히 확인받고 싶은 부분이 있으면 작성


## 🔗 참고 자료 (선택)

