### PR TITLE
[CHORE] css 수정, 불필요한 폰트 preload제거 (#111)

### DIFF
--- a/koco/index.html
+++ b/koco/index.html
@@ -16,17 +16,6 @@
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <title>KOCO</title>
-    <!-- HTML head에 MathJax 폰트 프리로드 추가 -->
-    <link
-      rel="preload"
-      href="https://cdn.jsdelivr.net/npm/mathjax@3/es5/output/svg/fonts/tex.js"
-      as="script"
-    />
-    <link
-      rel="preload"
-      href="https://cdn.jsdelivr.net/npm/mathjax@3/es5/output/svg/fonts/tex-script.js"
-      as="script"
-    />
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/orioncactus/Pretendard/dist/web/static/pretendard.css"

--- a/koco/src/styles/global.css
+++ b/koco/src/styles/global.css
@@ -95,12 +95,11 @@ mjx-container {
   white-space: normal !important;
   overflow-wrap: break-word !important;
   word-wrap: break-word !important;
-  position: static !important;
 }
 
-/* MathJax 관련 요소들의 position 초기화 */
+/* MathJax 관련 요소들의 position 초기화
 .MathJax,
 .MathJax_Display,
 .math-content {
   position: static !important;
-}
+} */


### PR DESCRIPTION
# TITLE [Chore] css 수정, 불필요한 폰트 preload제거 (#111)

## 📝 개요
배포 환경에서 확인 결과 수식 렌더링 문제가 해결되었고, 해당 과정에서 불필요하게 추가 했던 css, preload를 제거하였습니다.

## 🔗 연관된 이슈
- #111 

## 🔄 변경사항 및 이유
- 배포 환경에서 확인 결과 수식이 정상적으로 렌더링되었습니다.

## 📋 작업할 내용
- [x] preload 제거
- [x] css 수정 (positive: static)

## 🔖 기타사항
- [ ] 배포 환경에서 확인 필요

## 👀 리뷰 요구사항 (선택)
- 리뷰어에게 특별히 확인받고 싶은 부분이 있으면 작성

## 🔗 참고 자료 (선택)
