### PR TITLE
[CHORE] MathJax 라이브러리 렌더링 순서 제어 (#111) 

### DIFF
--- a/koco/src/pages/ProblemSolutionPage/components/ProblemDetailSection/index.tsx
+++ b/koco/src/pages/ProblemSolutionPage/components/ProblemDetailSection/index.tsx
@@ -30,10 +30,19 @@ const ProblemDetailSection = (data: IGetProblemSolutionResponse) => {
   const outputBlocks = divideExampleText(data.outputExample);
   const cleanedHtml = processMathHtml(data.description);
 
+  // useEffect(() => {
+  //   if (window.MathJax?.typesetPromise) {
+  //     window.MathJax.typesetPromise();
+  //   }
+  // }, [data]);
+
   useEffect(() => {
-    if (window.MathJax?.typesetPromise) {
-      window.MathJax.typesetPromise();
-    }
+    // 예시로 DOM이 완전히 그려진 뒤 실행
+    setTimeout(() => {
+      if (window.MathJax?.typesetPromise) {
+        window.MathJax.typesetPromise();
+      }
+    }, 0);
   }, [data]);
 
   return (

--- a/koco/src/styles/global.css
+++ b/koco/src/styles/global.css
@@ -95,10 +95,10 @@ mjx-container {
   white-space: normal !important;
   overflow-wrap: break-word !important;
   word-wrap: break-word !important;
-  position: static !important;
+  /* position: static !important; */
 }
 
-.MathJax_Display,
+/* .MathJax_Display,
 .math-content {
   position: static !important;
-}
+} */


### PR DESCRIPTION
# TITLE [CHORE] MathJax 라이브러리 렌더링 순서 제어 (#111) 
## 📝 개요
css가 로드된 후 MathJax가 렌더링 될 수 있도록 렌더링 순서를 제어합니다.

## 🔗 연관된 이슈
- #111

## 🔄 변경사항 및 이유
- 기존의 MathJax 라이브러리 렌더링을 위한 useEffect 코드에서 MathJax.typesetPromise()를 setTimeout에 맞춰 실행

## 📋 작업할 내용
- [x] typesetPromise 실행 시점 변경

## 🔖 기타사항

## 👀 리뷰 요구사항 (선택)
- 리뷰어에게 특별히 확인받고 싶은 부분이 있으면 작성

## 🔗 참고 자료 (선택)
- 관련 문서나 링크가 있으면 첨부
