### PR TITLE
[CHORE] 수식 관련 폰트가 먼저 렌더링 되도록 수정 (#111)

### DIFF
--- a/koco/package-lock.json
+++ b/koco/package-lock.json
@@ -14,6 +14,7 @@
         "axios": "^1.9.0",
         "better-react-mathjax": "^2.3.0",
         "chart.js": "^4.4.9",
+        "fontfaceobserver": "^2.3.0",
         "react": "^19.0.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.0.0",
@@ -3222,6 +3223,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fontfaceobserver": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/fontfaceobserver/-/fontfaceobserver-2.3.0.tgz",
+      "integrity": "sha512-6FPvD/IVyT4ZlNe7Wcn5Fb/4ChigpucKYSvD6a+0iMoLn2inpo711eyIcKjmDtE5XNcgAkSH9uN/nfAeZzHEfg=="
     },
     "node_modules/for-each": {
       "version": "0.3.5",

--- a/koco/package.json
+++ b/koco/package.json
@@ -17,6 +17,7 @@
     "axios": "^1.9.0",
     "better-react-mathjax": "^2.3.0",
     "chart.js": "^4.4.9",
+    "fontfaceobserver": "^2.3.0",
     "react": "^19.0.0",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.0.0",

--- a/koco/src/pages/ProblemSolutionPage/components/ProblemDetailSection/index.tsx
+++ b/koco/src/pages/ProblemSolutionPage/components/ProblemDetailSection/index.tsx
@@ -37,12 +37,11 @@ const ProblemDetailSection = (data: IGetProblemSolutionResponse) => {
   // }, [data]);
 
   useEffect(() => {
-    // 예시로 DOM이 완전히 그려진 뒤 실행
-    setTimeout(() => {
+    document.fonts.ready.then(() => {
       if (window.MathJax?.typesetPromise) {
         window.MathJax.typesetPromise();
       }
-    }, 0);
+    });
   }, [data]);
 
   return (


### PR DESCRIPTION
# TITLE [CHORE] 수식 관련 폰트가 먼저 렌더링 되도록 수정 (#111)
## 📝 개요
네트워크 탭을 확인해보니, CSS는 먼저 로드되고 있었으나 수식에 사용되는 폰트가 MathJax 라이브러리가 로드된 이후에 완료되는 현상이 있었습니다.

## 🔗 연관된 이슈
- #111
-
## 🔄 변경사항 및 이유
- 모든 폰트가 로드 되면 MathJax 라이브러리를 렌더링하도록 수정하였습니다.

## 📋 작업할 내용
- [x] `typesetPromise()` 호출 조건 수정

## 🔖 기타사항

## 👀 리뷰 요구사항 (선택)
- 리뷰어에게 특별히 확인받고 싶은 부분이 있으면 작성
- ex) "메서드 네이밍을 더 직관적으로 만들고 싶은데 조언 부탁드립니다."

## 🔗 참고 자료 (선택)
- 관련 문서나 링크가 있으면 첨부
