### PR TITLE
[FEATURE] 게시글 상세 UI 구현 및 api 연결 (#128 )

### DIFF
--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -17,4 +17,9 @@ export const queryKeys = {
     all: ['auth'] as const,
     status: ['auth', 'status'] as const,
   },
+
+  post: {
+    all: ['posts'] as const,
+    detail: (postId: number) => [...queryKeys.post.all, 'post', postId] as const,
+  },
 };

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -21,5 +21,6 @@ export const queryKeys = {
   post: {
     all: ['posts'] as const,
     detail: (postId: number) => [...queryKeys.post.all, 'post', postId] as const,
+    like: (postId: number) => ['post', postId, 'like'],
   },
 };

--- a/src/features/like/api/deleteLike.ts
+++ b/src/features/like/api/deleteLike.ts
@@ -1,0 +1,17 @@
+import { API_SUB_URLS_V3 } from '@/constants/apiConfig';
+import axiosInstance from '@/shared/lib/axios';
+import { IApiResponse } from '@/shared/types/ApiResponse';
+
+/**
+ * 좋아요 취소
+ * @param postId
+ */
+const deleteLike = async (postId: number) => {
+  const response = await axiosInstance.delete<IApiResponse<null>>(
+    `${API_SUB_URLS_V3}/posts/${postId}/likes`
+  );
+
+  return response.data.data;
+};
+
+export default deleteLike;

--- a/src/features/like/api/registerLike.ts
+++ b/src/features/like/api/registerLike.ts
@@ -1,0 +1,24 @@
+import { API_SUB_URLS_V3 } from '@/constants/apiConfig';
+import axiosInstance from '@/shared/lib/axios';
+import { IApiResponse } from '@/shared/types/ApiResponse';
+
+interface IRegisterLikeResponse {
+  postId: number;
+  liked: boolean;
+  likeCount: number;
+}
+
+/**
+ * 좋아요 등록
+ * @param postId
+ * @returns postId, liked, likeCount
+ */
+const registerLike = async (postId: number) => {
+  const response = await axiosInstance.post<IApiResponse<IRegisterLikeResponse>>(
+    `${API_SUB_URLS_V3}/posts/${postId}/likes`
+  );
+
+  return response.data.data;
+};
+
+export default registerLike;

--- a/src/features/like/hooks/useDeleteLike.ts
+++ b/src/features/like/hooks/useDeleteLike.ts
@@ -5,9 +5,9 @@ import deleteLike from '../api/deleteLike';
  * 좋아요 삭제
  * @param postId
  */
-const useDeleteLike = (postId: number) => {
+const useDeleteLike = () => {
   return useMutation({
-    mutationFn: () => deleteLike(postId),
+    mutationFn: (postId: number) => deleteLike(postId),
   });
 };
 

--- a/src/features/like/hooks/useDeleteLike.ts
+++ b/src/features/like/hooks/useDeleteLike.ts
@@ -1,0 +1,14 @@
+import { useMutation } from '@tanstack/react-query';
+import deleteLike from '../api/deleteLike';
+
+/**
+ * 좋아요 삭제
+ * @param postId
+ */
+const useDeleteLike = (postId: number) => {
+  return useMutation({
+    mutationFn: () => deleteLike(postId),
+  });
+};
+
+export default useDeleteLike;

--- a/src/features/like/hooks/useRegisterLike.ts
+++ b/src/features/like/hooks/useRegisterLike.ts
@@ -1,14 +1,12 @@
-import { queryKeys } from '@/constants/queryKeys';
 import { useMutation } from '@tanstack/react-query';
 import registerLike from '../api/registerLike';
 
 /**
  * 좋아요 등록 훅
  */
-const useRegisterLike = (postId: number) => {
+const useRegisterLike = () => {
   return useMutation({
-    mutationKey: queryKeys.post.like(postId),
-    mutationFn: () => registerLike(postId),
+    mutationFn: (postId: number) => registerLike(postId),
   });
 };
 

--- a/src/features/like/hooks/useRegisterLike.ts
+++ b/src/features/like/hooks/useRegisterLike.ts
@@ -1,0 +1,15 @@
+import { queryKeys } from '@/constants/queryKeys';
+import { useMutation } from '@tanstack/react-query';
+import registerLike from '../api/registerLike';
+
+/**
+ * 좋아요 등록 훅
+ */
+const useRegisterLike = (postId: number) => {
+  return useMutation({
+    mutationKey: queryKeys.post.like(postId),
+    mutationFn: () => registerLike(postId),
+  });
+};
+
+export default useRegisterLike;

--- a/src/features/post/api/getPostDetail.ts
+++ b/src/features/post/api/getPostDetail.ts
@@ -1,0 +1,38 @@
+import { API_SUB_URLS_V3 } from '@/constants/apiConfig';
+import axiosInstance from '@/shared/lib/axios';
+import { IApiResponse } from '@/shared/types/ApiResponse';
+
+type Category = {
+  categoryId: number;
+  categoryName: string;
+};
+
+type Author = {
+  userId: number;
+  nickname: string;
+  imgUrl: string;
+};
+
+export interface IGetPostDetailResponse {
+  postId: number;
+  title: string;
+  createdAt: string;
+  categories: Category[];
+  content: string;
+  author: Author;
+  commentCount: number;
+  likeCount: number;
+  liked: boolean;
+}
+
+/**
+ * GET) 게시글 상세 조회
+ * @path postId
+ */
+export const getPostDetail = async (postId: number) => {
+  const response = await axiosInstance.get<IApiResponse<IGetPostDetailResponse>>(
+    `${API_SUB_URLS_V3}/posts/${postId}`
+  );
+
+  return response.data.data;
+};

--- a/src/features/post/components/CommentCountBox.tsx
+++ b/src/features/post/components/CommentCountBox.tsx
@@ -1,0 +1,23 @@
+interface ICommentCount {
+  commentCount: number;
+}
+
+const CommentCountBox = ({ commentCount }: ICommentCount) => {
+  return (
+    <div className="flex items-center gap-4">
+      {' '}
+      <svg
+        className="w-5 h-5 transition-colors duration-200"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      >
+        <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+      </svg>
+      <span className="font-medium transition-colors duration-200">{commentCount}</span>
+    </div>
+  );
+};
+
+export default CommentCountBox;

--- a/src/features/post/components/LikeBoxWithActions.tsx
+++ b/src/features/post/components/LikeBoxWithActions.tsx
@@ -1,0 +1,107 @@
+import useDeleteLike from '@/features/like/hooks/useDeleteLike';
+import useRegisterLike from '@/features/like/hooks/useRegisterLike';
+import { useState } from 'react';
+
+interface ILikeWithActionsProps {
+  liked: boolean;
+  likeCount: number;
+  postId: number;
+}
+
+const LikeWithActions = ({ liked, likeCount, postId }: ILikeWithActionsProps) => {
+  const [isAnimating, setIsAnimating] = useState(false);
+  const [localLike, setLocalLike] = useState(liked);
+  const [localLikeCount, setLocalLikeCount] = useState(likeCount);
+  const registerLikeMutation = useRegisterLike();
+  const deleteLikeMutation = useDeleteLike();
+
+  const handleLike = async () => {
+    if (isAnimating) return;
+
+    if (localLike && localLikeCount > 0) {
+      try {
+        deleteLikeMutation.mutateAsync(postId);
+        setLocalLike(prev => !prev);
+        setLocalLikeCount(prev => prev - 1);
+
+        return;
+      } catch {
+        return;
+      }
+    }
+    if (!localLike) {
+      try {
+        // 애니메이션 시작
+        setIsAnimating(true);
+        registerLikeMutation.mutateAsync(postId);
+        setLocalLike(prev => !prev);
+        setLocalLikeCount(prev => prev + 1);
+
+        // 애니메이션 종료
+        setTimeout(() => {
+          setIsAnimating(false);
+        }, 300);
+      } catch {
+        alert('좋아요 등록 실패');
+      }
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-4">
+      {/* 좋아요 버튼 */}
+      <button
+        onClick={handleLike}
+        disabled={isAnimating}
+        className={`
+              relative flex items-center gap-2 px-3 py-2 rounded-xl font-medium text-sm
+              transition-all duration-200 ease-out select-none
+              ${
+                localLike
+                  ? 'bg-red-50 text-red-600 hover:bg-red-100'
+                  : 'hover:bg-gray-100 text-text-secondary hover:text-red-600'
+              }
+              ${isAnimating ? 'scale-105' : 'hover:scale-[1.02]'}
+            `}
+      >
+        {/* 하트 아이콘 */}
+        <div className="relative">
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            className={`
+                  transition-all duration-300 ease-out
+                  ${localLike ? 'fill-current scale-110' : 'fill-none'}
+                  ${isAnimating ? 'animate-pulse' : ''}
+                `}
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+          </svg>
+
+          {/* 좋아요 애니메이션 효과 */}
+          {isAnimating && localLike && (
+            <div className="absolute inset-0 -m-2">
+              <div className="w-6 h-6 bg-red-500 rounded-full opacity-20 animate-ping" />
+            </div>
+          )}
+        </div>
+
+        {/* 좋아요 카운트 */}
+        <span
+          className={`
+              font-medium transition-all duration-300 ease-out
+              ${isAnimating ? 'scale-105' : ''}
+              ${localLike ? 'text-red-600' : ''}
+            `}
+        >
+          {localLikeCount}
+        </span>
+      </button>
+    </div>
+  );
+};
+
+export default LikeWithActions;

--- a/src/features/post/components/PostContent.tsx
+++ b/src/features/post/components/PostContent.tsx
@@ -1,0 +1,15 @@
+import MDEditor from '@uiw/react-md-editor';
+
+interface IPostContentProps {
+  content: string;
+}
+
+const PostContent = ({ content }: IPostContentProps) => {
+  return (
+    <div className="py-4">
+      <MDEditor.Markdown source={content} />
+    </div>
+  );
+};
+
+export default PostContent;

--- a/src/features/post/components/PostContent.tsx
+++ b/src/features/post/components/PostContent.tsx
@@ -6,7 +6,7 @@ interface IPostContentProps {
 
 const PostContent = ({ content }: IPostContentProps) => {
   return (
-    <div className="py-4">
+    <div className="py-6">
       <MDEditor.Markdown source={content} />
     </div>
   );

--- a/src/features/post/components/PostMeta.tsx
+++ b/src/features/post/components/PostMeta.tsx
@@ -1,0 +1,68 @@
+import { CategoryBox } from '@/shared/ui/CategoryBox';
+import { formatDate } from '@/utils/formatDate';
+
+type Author = {
+  imgUrl: string;
+  nickname: string;
+};
+
+type Category = {
+  categoryName: string;
+  categoryId: number;
+};
+
+interface IPostMetaProps {
+  title: string;
+  createdAt: string;
+  categories: Category[];
+  author: Author;
+}
+
+const PostMeta = (data: IPostMetaProps) => {
+  return (
+    <div className="border-b-[2px] border-border">
+      <div className="flex justify-between">
+        <h2 className="text-2xl font-bold text-text-primary mb-4">{data.title}</h2>
+        <button className="p-2 hover:bg-gray-100 rounded-lg transition-colors">
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <circle cx="12" cy="12" r="1" />
+            <circle cx="19" cy="12" r="1" />
+            <circle cx="5" cy="12" r="1" />
+          </svg>
+        </button>
+      </div>
+
+      <div className="flex items-center gap-3 mb-4">
+        <img
+          src={data.author.imgUrl}
+          alt={data.author.nickname}
+          className="w-8 h-8 rounded-full object-cover"
+        />
+        <div className="flex-1">
+          <div className="flex items-center gap-2">
+            <span className="font-semibold text-text-primary">{data.author.nickname}</span>
+            <span className="text-text-secondary text-sm">•</span>
+            <span className="text-text-secondary text-sm">{formatDate(data.createdAt)}</span>
+          </div>
+        </div>
+      </div>
+      {/* 알고리즘 유형 */}
+      {data.categories && data.categories.length > 0 && (
+        <div className="flex flex-wrap gap-2 mb-4">
+          {data.categories.map(category => (
+            <CategoryBox key={category.categoryId} name={category.categoryName} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PostMeta;

--- a/src/features/post/hooks/useGetPostDetail.ts
+++ b/src/features/post/hooks/useGetPostDetail.ts
@@ -1,0 +1,20 @@
+import { queryKeys } from '@/constants/queryKeys';
+import { useQuery } from '@tanstack/react-query';
+import { getPostDetail } from '../api/getPostDetail';
+
+/**
+ * 게시글 상세 조회 훅
+ * @param postId
+ */
+const useGetPostDetail = (postId: number) => {
+  return useQuery({
+    queryKey: queryKeys.post.detail(postId),
+    queryFn: () => getPostDetail(postId),
+    staleTime: 0,
+    gcTime: 1000 * 60 * 1,
+    enabled: !!postId,
+    refetchOnMount: true,
+  });
+};
+
+export default useGetPostDetail;

--- a/src/pages/PostDetailPage/index.tsx
+++ b/src/pages/PostDetailPage/index.tsx
@@ -1,9 +1,42 @@
+import useGetPostDetail from '@/features/post/hooks/useGetPostDetail';
+import BottomNav from '@/shared/layout/BottomNav';
 import PageHeader from '@/shared/layout/PageHeader';
+import { useParams } from 'react-router-dom';
 
 const PostDetailPage = () => {
+  const { id } = useParams();
+  const numericId = id ? parseInt(id, 10) : undefined;
+  const { data: postDetailData, isLoading, isError } = useGetPostDetail(numericId as number);
+
+  // 로딩 중이거나 데이터가 없는 경우 로딩 표시
+  if (isLoading) {
+    return (
+      <div>
+        <PageHeader title="게시글 상세" />
+        <div className="flex justify-center items-center h-[60vh]">
+          <p>로딩 중...</p>
+        </div>
+        <BottomNav />
+      </div>
+    );
+  }
+
+  if (isError || !postDetailData) {
+    return (
+      <div>
+        <PageHeader title="게시글 상세" />
+        <div className="flex justify-center items-center h-[60vh]">
+          <p>게시글 정보가 없습니다</p>
+        </div>
+        <BottomNav />
+      </div>
+    );
+  }
+
   return (
     <div className="bg-background min-h-screen relative">
       <PageHeader title="게시글 상세" />
+      <div className="px-6">{postDetailData.author.nickname}</div>
     </div>
   );
 };

--- a/src/pages/PostDetailPage/index.tsx
+++ b/src/pages/PostDetailPage/index.tsx
@@ -1,3 +1,5 @@
+import PostContent from '@/features/post/components/PostContent';
+import PostMeta from '@/features/post/components/PostMeta';
 import useGetPostDetail from '@/features/post/hooks/useGetPostDetail';
 import BottomNav from '@/shared/layout/BottomNav';
 import PageHeader from '@/shared/layout/PageHeader';
@@ -36,7 +38,17 @@ const PostDetailPage = () => {
   return (
     <div className="bg-background min-h-screen relative">
       <PageHeader title="게시글 상세" />
-      <div className="px-6">{postDetailData.author.nickname}</div>
+      <main className="px-6">
+        <article>
+          <PostMeta
+            categories={postDetailData.categories}
+            title={postDetailData.title}
+            author={postDetailData.author}
+            createdAt={postDetailData.createdAt}
+          />
+          <PostContent content={postDetailData.content} />
+        </article>
+      </main>
     </div>
   );
 };

--- a/src/pages/PostDetailPage/index.tsx
+++ b/src/pages/PostDetailPage/index.tsx
@@ -1,3 +1,5 @@
+import CommentCountBox from '@/features/post/components/CommentCountBox';
+import LikeBoxWithActions from '@/features/post/components/LikeBoxWithActions';
 import PostContent from '@/features/post/components/PostContent';
 import PostMeta from '@/features/post/components/PostMeta';
 import useGetPostDetail from '@/features/post/hooks/useGetPostDetail';
@@ -39,7 +41,7 @@ const PostDetailPage = () => {
     <div className="bg-background min-h-screen relative">
       <PageHeader title="게시글 상세" />
       <main className="px-6">
-        <article>
+        <article className="border-b-[2px] border-border">
           <PostMeta
             categories={postDetailData.categories}
             title={postDetailData.title}
@@ -47,6 +49,14 @@ const PostDetailPage = () => {
             createdAt={postDetailData.createdAt}
           />
           <PostContent content={postDetailData.content} />
+          <div className=" flex gap-2 justify-end mt-4 mb-4">
+            <LikeBoxWithActions
+              postId={postDetailData.postId}
+              liked={postDetailData.liked}
+              likeCount={postDetailData.likeCount}
+            />
+            <CommentCountBox commentCount={postDetailData.commentCount} />
+          </div>
         </article>
       </main>
     </div>

--- a/src/shared/ui/CategoryBox/index.tsx
+++ b/src/shared/ui/CategoryBox/index.tsx
@@ -1,14 +1,16 @@
+import { convertEnglishCategoryToKorean } from '@/utils/doMappingCategories';
+
 interface ICategoryBox {
   name: string;
-  className?: string;
 }
 
-export const CategoryBox = ({ name, className = '' }: ICategoryBox) => {
+export const CategoryBox = ({ name }: ICategoryBox) => {
   return (
     <div
-      className={`inline-block bg-category border border-border-focused rounded-2xl px-2 py-1 text-sm ${className}`}
+      key={name}
+      className="flex items-center gap-1 bg-secondary text-white px-3 py-1 rounded-full text-sm whitespace-nowrap"
     >
-      {name}
+      <span> {convertEnglishCategoryToKorean(name)}</span>
     </div>
   );
 };

--- a/src/utils/doMappingCategories.ts
+++ b/src/utils/doMappingCategories.ts
@@ -19,8 +19,15 @@ export const convertKoreanToEnglish = (koreanCategories: string[]): string[] => 
 };
 
 /**
- * 영어 카테고리를 한글로 변환
+ * 영어 카테고리 배열을 한글로 변환
  */
 export const convertEnglishToKorean = (englishCategories: string[]): string[] => {
   return englishCategories.map(english => ALGORITHM_CATEGORY_MAPPING[english]).filter(Boolean); // undefined 제거
+};
+
+/**
+ * 영어 카테고리를 한글로 변환
+ */
+export const convertEnglishCategoryToKorean = (englishCategory: string): string => {
+  return ALGORITHM_CATEGORY_MAPPING[englishCategory]; // undefined 제거
 };


### PR DESCRIPTION
# [FEATURE] 게시글 상세 UI 구현 및 api 연결 (#128 )

## 📝 개요
게시글 상세 페이지의 메타 컴포넌트, 마크다운 컨텐츠, 좋아요/댓글 수 컴포넌트를 구현하였습니다.

## 🔗 연관된 이슈
- closes #128 

## 🔄 변경사항 및 이유
- `CategoryBox` 컴포넌트 디자인 수정
- 기존에는 배열 단위로 가능했지만 단일 항목 카테고리 영어 -> 한글 변환하는 함수 구현

## 📋 작업할 내용
- [x] `PostMeta` 컴포넌트 구현
- [x] `PostContent` 컴포넌트 구현
- [x] 좋아요/댓글 수를 보여주는 컴포넌트 구현

## 🔖 기타사항

## 👀 리뷰 요구사항 (선택)

## 🔗 참고 자료 (선택)

