### PR TITLE
[FEATURE] 댓글 조회 무한 스크롤 적용 (#142)

### DIFF
--- a/src/features/comment/api/getCommentList.ts
+++ b/src/features/comment/api/getCommentList.ts
@@ -16,15 +16,22 @@ type Author = {
 };
 interface ICommentListResponse {
   postId: number;
-  nextCursorId: number;
+  nextCursorId: number | null;
   hasNext: boolean;
   comments: Comment[];
 }
 
-const getCommentList = async (postId: number) => {
-  const response = await axiosInstance.get<IApiResponse<ICommentListResponse>>(
-    `${API_SUB_URLS_V3}/posts/${postId}/comments`
-  );
+interface IGetCommentListProps {
+  pageParam: number | null;
+  postId: number;
+}
+
+const getCommentList = async ({ pageParam, postId }: IGetCommentListProps) => {
+  const url = pageParam
+    ? `${API_SUB_URLS_V3}/posts/${postId}/comments?cursorId=${pageParam}`
+    : `${API_SUB_URLS_V3}/posts/${postId}/comments`;
+
+  const response = await axiosInstance.get<IApiResponse<ICommentListResponse>>(url);
 
   return response.data.data;
 };

--- a/src/features/comment/hooks/useGetCommentList.ts
+++ b/src/features/comment/hooks/useGetCommentList.ts
@@ -1,13 +1,17 @@
 import { queryKeys } from '@/constants/queryKeys';
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import getCommentList from '../api/getCommentList';
 
 const useGetCommentList = (postId: number) => {
-  return useQuery({
+  return useInfiniteQuery({
     queryKey: queryKeys.post.comment(postId),
-    queryFn: () => getCommentList(postId),
+    queryFn: ({ pageParam = 1 }) => getCommentList({ pageParam: pageParam ?? null, postId }),
+    initialPageParam: null as number | null,
+    getNextPageParam: lastPage => {
+      return lastPage.hasNext ? lastPage.nextCursorId : undefined;
+    },
     staleTime: 0,
-    gcTime: 1000 * 60,
+    gcTime: 0,
     refetchOnMount: true,
   });
 };

--- a/src/shared/hooks/useInfiniteScroll.ts
+++ b/src/shared/hooks/useInfiniteScroll.ts
@@ -1,0 +1,37 @@
+/**
+ * 무한 스크롤
+ */
+
+import { useRef, useCallback } from 'react';
+
+interface IUseInfiniteScrollProps {
+  isLoading: boolean;
+  hasNextPage: boolean;
+  fetchNextPage: () => void;
+}
+
+export const useInfiniteScroll = ({
+  isLoading,
+  hasNextPage,
+  fetchNextPage,
+}: IUseInfiniteScrollProps) => {
+  const observer = useRef<IntersectionObserver | null>(null);
+
+  const lastElementRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (isLoading) return;
+      if (observer.current) observer.current.disconnect();
+
+      observer.current = new IntersectionObserver(entries => {
+        if (entries[0].isIntersecting && hasNextPage) {
+          fetchNextPage();
+        }
+      });
+
+      if (node) observer.current.observe(node);
+    },
+    [isLoading, hasNextPage, fetchNextPage]
+  );
+
+  return lastElementRef;
+};


### PR DESCRIPTION
# [FEATURE] 댓글 조회 무한 스크롤 적용 (#142)

## 📝 개요
10개씩 fetch 해올 수 있도록 무한 스크롤을 적용합니다.

## 🔗 연관된 이슈
- closes #142 

## 🔄 변경사항 및 이유
- `useGetCommentList` 훅 `useQuery` -> `useInfiniteQuery` 로 메소드 변경
- `getCommentList` (댓글 조회 api 호출 함수)를 pageParam을 request parameter로 받아 api 호출하도록 수정
- 기존의 commentItem 렌더링 방법 변경 (페이지의 마지막 요소에 ref 달도록 수정)

## 📋 작업할 내용
- [x] `useInfiniteQuery` 리서치
- [x] `useInfiniteScroll` 무한 스크롤 적용을 위한 ref 옵저버 커스텀 훅 구현
- [x] 댓글 렌더링 방식 수정 

## 🔖 기타사항

## 🔗 참고 자료 (선택)
https://tanstack.com/query/latest/docs/framework/react/reference/useInfiniteQuery
https://oliveyoung.tech/2023-10-04/useInfiniteQuery-scroll/

