### PR TITLE
[FEATURE] 춘식이 키우기 게임 바로가기 연결, Card props 수정 (#146)

### DIFF
--- a/src/pages/MainPage/components/ChunsikCard/index.tsx
+++ b/src/pages/MainPage/components/ChunsikCard/index.tsx
@@ -1,11 +1,18 @@
 import Card from '@/shared/ui/Card';
 import ChunsikImage from '@/assets/chunsikImage.png';
 
-const ChunsikCard = () => (
-  <Card className="!bg-primary flex items-center  text-white p-4 justify-between">
+interface IChunsikCardProps {
+  onClick: () => void;
+}
+
+const ChunsikCard = ({ onClick }: IChunsikCardProps) => (
+  <Card
+    onClick={onClick}
+    className="!bg-primary flex items-center  text-white p-4 justify-between cursor-pointer"
+  >
     <div>
-      <p className="text-bold-14">춘식이가 열심히 응원하고 있어요</p>
-      <p className="text-regular-14">카테부 화이팅💞</p>
+      <p className="text-bold-14">춘식이 키우기</p>
+      <p className="text-regular-14">미니게임 바로 가기</p>
     </div>
     <div className="flex flex-shrink-0">
       <img src={ChunsikImage} width={65} />

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -19,6 +19,10 @@ const MainPage = () => {
   const today = new Date().toISOString().split('T')[0];
   const { data: todayProblemData, isLoading: isTodayProblemLoading } = useProblemSet(today);
 
+  const handleOpenGame = () => {
+    window.open('/game/', '_blank');
+  };
+
   // ⏳ 로딩 중
   if (isUserProfileLoading || isUserStudyStatLoading || isTodayProblemLoading) {
     return (
@@ -82,7 +86,7 @@ const MainPage = () => {
       </div>
 
       <TotalStudyCard studyStats={userStudyStatData.studyStats} />
-      <ChunsikCard />
+      <ChunsikCard onClick={handleOpenGame} />
       <BottomNav />
     </div>
   );

--- a/src/shared/ui/Card/index.tsx
+++ b/src/shared/ui/Card/index.tsx
@@ -1,5 +1,13 @@
-const Card = ({ className = '', children }: { className?: string; children: React.ReactNode }) => (
-  <div className={`bg-surface rounded-xl border-1 border-border ${className}`}>{children}</div>
+interface ICardProps {
+  className?: string;
+  children: React.ReactNode;
+  onClick?: () => void;
+}
+
+const Card = ({ className = '', children, onClick }: ICardProps) => (
+  <div onClick={onClick} className={`bg-surface rounded-xl border-1 border-border ${className}`}>
+    {children}
+  </div>
 );
 
 export default Card;


### PR DESCRIPTION
# [FEATURE] 춘식이 키우기 게임 바로가기 연결, Card props 수정 (#146)

## 📝 개요
라우팅 수정 및 기존 card 컴포넌트 수정, 춘식이 배너 수정

## 🔗 연관된 이슈
- close #146 

## 🔄 변경사항 및 이유
- Card 컴포넌트 내 onClick 이벤트 props로 추가
- 춘식이 배너 클릭 시 `/game/` 으로 이동하도록 라우팅 추가 (새 탭 이동)
- 춘식이 배너 문구 수정

## 📋 작업할 내용
- [x] 춘식이 키우기 게임 연결

## 🔖 기타사항

## 👀 리뷰 요구사항

## 🔗 참고 자료
