### PR TITLE
[CHORE] 수정 페이지에 problemNumber 전달, 응답 타입 수정 (#156)

### DIFF
--- a/src/features/post/api/getPostDetail.ts
+++ b/src/features/post/api/getPostDetail.ts
@@ -14,6 +14,7 @@ type Author = {
 };
 
 export interface IGetPostDetailResponse {
+  problemNumber: number;
   postId: number;
   title: string;
   createdAt: string;

--- a/src/pages/PostDetailPage/index.tsx
+++ b/src/pages/PostDetailPage/index.tsx
@@ -67,7 +67,7 @@ const PostDetailPage = () => {
         initialData: {
           postId: id,
           post: {
-            problemNumber: 23,
+            problemNumber: postDetailData.problemNumber,
             title: postDetailData.title,
             content: postDetailData.content,
             category: postDetailData.categories,


### PR DESCRIPTION
# [CHORE] 수정 페이지에 problemNumber 전달, 응답 타입 수정 (#156)

## 📝 개요
게시글 수정 페이지 이동 시 초기화 되는 값에 `problemNumber`를 추가하였습니다.

## 🔗 연관된 이슈
- #156

## 🔄 변경사항 및 이유
-  `getPostDetail` 응답 데이터 수정으로 인한 타입 수정
- 편집 페이지 이동 시 초기화 되는 값에 `problemNumber` 추가

## 📋 작업할 내용
- [ ] 응답 타입 수정
- [ ] 편집 페이지 이동시 라우터 state로 `problemNumber` 전달

## 🔖 기타사항

