### PR TITLE
[FIX] 게시글 등록시 카테고리 미전송 되는 이슈 해결 (#164)

### DIFF
--- a/src/features/post/api/getPostList.ts
+++ b/src/features/post/api/getPostList.ts
@@ -37,11 +37,12 @@ export interface IGetPostListProps {
 }
 
 const getPostList = async ({ keyword, category, pageParam }: IGetPostListProps) => {
+  console.log(category);
   const response = await axiosInstance.get<IApiResponse<IGetPostListResponse>>(
     `${API_SUB_URLS_V3}/posts`,
     {
       params: {
-        category,
+        ...(category && category.length > 0 && { category }),
         keyword: keyword || '',
         cursorId: pageParam || '',
       },

--- a/src/features/post/hooks/useCreatePost.ts
+++ b/src/features/post/hooks/useCreatePost.ts
@@ -1,13 +1,10 @@
 import { useMutation } from '@tanstack/react-query';
 import { createPost, ICreatePostRequest } from '../api/createPost';
-import { useNavigate } from 'react-router-dom';
 
 /**
  * 게시글 등록 뮤테이션 훅
  * */
 export const useCreatePost = () => {
-  const navigate = useNavigate();
-
   return useMutation({
     mutationFn: (data: ICreatePostRequest) => createPost(data),
   });

--- a/src/pages/CreatePostPage/index.tsx
+++ b/src/pages/CreatePostPage/index.tsx
@@ -1,7 +1,6 @@
 import PostForm, { IPostFormData } from '@/features/post/components/PostForm';
 import { useCreatePost } from '@/features/post/hooks/useCreatePost';
 import PageHeader from '@/shared/layout/PageHeader';
-import { convertKoreanToEnglish } from '@/utils/doMappingCategories';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -13,15 +12,12 @@ const CreatePostPage = () => {
   const handleCreatePost = (data: IPostFormData) => {
     try {
       setIsLoading(true);
-
-      console.log('게시물 생성시 데이터', data);
-
       createPostMutation.mutateAsync(
         {
           problemNumber: data.post.problemNumber,
           title: data.post.title,
           content: data.post.content,
-          category: data.post.category && convertKoreanToEnglish(data.post.category),
+          category: data.post.category,
         },
         {
           onSuccess: response => {

--- a/src/pages/PostsPage/index.tsx
+++ b/src/pages/PostsPage/index.tsx
@@ -61,7 +61,6 @@ const PostsPage = () => {
 
   // 검색 처리 & input 값 초기화
   const handleSearch = () => {
-    console.log('검색한 값', searchValue);
     setAppliedKeyword(searchValue.trim());
     resetInputValue();
   };


### PR DESCRIPTION
# [FIX] 게시글 등록시 카테고리 미전송 되는 이슈 해결 (#164)

## 📝 개요
카테고리 선택 후 게시글 등록 시 카테고리가 전송되지 않았던 이슈가 있어, 해결하였습니다.

## 🔗 연관된 이슈
- closes #164 

## 🔄 변경사항 및 이유
- 게시글 생성 api 함수인 `createPost`로 request data를 넘기는 과정에서 카테고리를 정상적으로 넘기지 않는 것을 확인해 수정하였습니다.
- 불필요한 콘솔 제거

## 📋 작업할 내용
- [x] 게시글 등록 테스트

## 🔖 기타사항

