### PR TITLE
[FIX] 하단 네비게이션 바에 항목(1개) 가려지는 현상 (#160)

### DIFF
--- a/src/pages/PostDetailPage/index.tsx
+++ b/src/pages/PostDetailPage/index.tsx
@@ -101,7 +101,7 @@ const PostDetailPage = () => {
             <CommentCountBox commentCount={postDetailData.commentCount} />
           </div>
         </article>
-        <section>
+        <section className="pb-20">
           <CommentInputBox postId={postDetailData.postId} />
           {/* 댓글 목록 */}
           {allComments.length > 0

--- a/src/pages/PostsPage/index.tsx
+++ b/src/pages/PostsPage/index.tsx
@@ -66,7 +66,7 @@ const PostsPage = () => {
   const allPosts = PostListData?.pages?.flatMap(page => page.posts) || [];
 
   return (
-    <div className="bg-background min-h-screen relative">
+    <div className="bg-background min-h-screen relative pb-20">
       <PageHeader title="커뮤니티" />
       <SearchInput
         className="mr-6 ml-6"


### PR DESCRIPTION
# [FIX] 하단 네비게이션 바에 항목(1개) 가려지는 현상 (#160)

## 📝 개요
하단 네비게이션 바에 의해 항목이 가려지는 이슈가 있어, padding-bottom으로 하단 네비게이션 바 높이 만큼 주었습니다.

## 🔗 연관된 이슈
- closes #160 

## 🔄 변경사항 및 이유
- 각 목록 태그에 `pb-20` 추가

## 📋 작업할 내용
- [x] 댓글 목록 레이아웃 수정
- [x] 게시글 목록 레이아웃 수정

## 🔖 기타사항
