### PR TITLE
[FIX] 게시글 수정 페이지 내 버그 해결 (#173)

### DIFF
--- a/src/features/post/api/getMyPosts.ts
+++ b/src/features/post/api/getMyPosts.ts
@@ -1,4 +1,4 @@
-import { API_SUB_URLS, API_SUB_URLS_V3 } from '@/constants/apiConfig';
+import { API_SUB_URLS } from '@/constants/apiConfig';
 import axiosInstance from '@/shared/lib/axios';
 import { IApiResponse } from '@/shared/types/ApiResponse';
 

--- a/src/features/post/api/getPostList.ts
+++ b/src/features/post/api/getPostList.ts
@@ -37,7 +37,6 @@ export interface IGetPostListProps {
 }
 
 const getPostList = async ({ keyword, category, pageParam }: IGetPostListProps) => {
-  console.log(category);
   const response = await axiosInstance.get<IApiResponse<IGetPostListResponse>>(
     `${API_SUB_URLS_V3}/posts`,
     {
@@ -51,7 +50,6 @@ const getPostList = async ({ keyword, category, pageParam }: IGetPostListProps) 
       },
     }
   );
-  console.log(response.data.data);
 
   return response.data.data;
 };

--- a/src/features/post/components/PostForm.tsx
+++ b/src/features/post/components/PostForm.tsx
@@ -8,6 +8,8 @@ import Input from '@/shared/ui/Input';
 import { convertKoreanToEnglish } from '@/utils/doMappingCategories';
 import MDEditor from '@uiw/react-md-editor';
 import { useMemo, useState } from 'react';
+import { Category } from '../api/getPostList';
+import { convertEnglishToKorean } from '@/utils/doMappingCategories';
 
 export type Post = {
   problemNumber: number;
@@ -20,8 +22,19 @@ export interface IPostFormData {
   post: Post;
 }
 
+export type PostFormInitialData = {
+  problemNumber: number;
+  title: string;
+  content: string;
+  category: Category[];
+};
+
+export interface IPostFormInitialData {
+  post: PostFormInitialData;
+}
+
 interface IPostFormProps {
-  initialData?: IPostFormData;
+  initialData?: IPostFormInitialData;
   onSubmit: (post: IPostFormData) => Promise<void> | void;
   submitButtonText: string;
   isLoading?: boolean;
@@ -38,8 +51,12 @@ const PostForm = ({
   const { value: problemNumber, onChange: problemNumberOnChange } = useInput(
     initialData?.post.problemNumber?.toString() || ''
   );
+  const categoryNames = initialData?.post.category
+    ? Object.values(initialData.post.category).map(item => item.categoryName)
+    : [];
+
   const { selectedAlgorithmTypes, handleToggleAlgorithmType, handleClearAllTypes } =
-    useAlgorithmDropdown();
+    useAlgorithmDropdown(convertEnglishToKorean(categoryNames));
 
   // 문제 번호 유효성 검사
   const problemNumberErr = useMemo(() => {
@@ -92,7 +109,6 @@ const PostForm = ({
         category: category,
       },
     };
-    //console.log(formData);
 
     await onSubmit(postData);
   };

--- a/src/features/post/hooks/useGetPostList.ts
+++ b/src/features/post/hooks/useGetPostList.ts
@@ -2,8 +2,6 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import getPostList from '../api/getPostList';
 
 const useGetPostList = ({ category, keyword }: { category: string[]; keyword: string }) => {
-  console.log(keyword);
-
   return useInfiniteQuery({
     queryKey: ['posts', category, keyword],
     queryFn: ({ pageParam }) => getPostList({ pageParam, category, keyword }),

--- a/src/pages/EditPostPage/index.tsx
+++ b/src/pages/EditPostPage/index.tsx
@@ -19,15 +19,17 @@ const EditPostPage = () => {
   }
 
   const handleUpdatePost = (postFormData: IPostFormData) => {
-    console.log('수정 요청');
     setIsLoading(true);
 
     if (!numericId) return;
     try {
-      editPostMutation.mutateAsync({
-        postId: numericId,
-        post: postFormData.post,
-      });
+      editPostMutation.mutateAsync(
+        {
+          postId: numericId,
+          post: postFormData.post,
+        },
+        { onSuccess: () => navigate(`/post/${numericId}`) }
+      );
     } catch {
       alert('수정 요청이 실패하였습니다.');
     } finally {


### PR DESCRIPTION
# [FIX] 게시글 수정 페이지 내 버그 해결 (#173)

## 📝 개요
아래와 같은 이슈를 해결하였습니다.

- 수정 완료 후 게시글 페이지로 이동하지 않는 문제
- 게시글 상세 페이지에서 수정 페이지로 이동시 카테고리가 정상적으로 넘어가지 않아 값이 초기화 되어 있지 않은 문제

## 🔗 연관된 이슈
- closes #173 

## 🔄 변경사항 및 이유
- `useAlgorithmDropdown` 훅에서 영어->한글로 번역한 카테고리 초기화 하도록 수정
- 수정 완료 후 `post/${postId}` 로 이동하도록 수정
- 불필요한 콘솔 제거

## 📋 작업할 내용
- [x] 카테고리 초기화
- [x] 수정 후 `onSuccess` 콜백 함수 추가

## 🔖 기타사항

