### PR TITLE
[FEATURE] 알람 메시지에 데이터 추가, 유틸 함수 분리 (#183)

### DIFF
--- a/src/features/alarm/api/getAlarmList.ts
+++ b/src/features/alarm/api/getAlarmList.ts
@@ -7,7 +7,7 @@ interface IGetAlarmListProps {
   pageParam: number | null;
 }
 
-type Alarm = {
+export type Alarm = {
   id: number;
   senderId: number;
   postId: number;

--- a/src/features/alarm/utils/getAlarmMessage.ts
+++ b/src/features/alarm/utils/getAlarmMessage.ts
@@ -1,0 +1,20 @@
+import { Alarm } from '../api/getAlarmList';
+/**
+ * 알람 타입에 따라 한글+전치사로 변환하는 함수
+ * @param type
+ */
+const getNotificationText = (type: string) => {
+  switch (type) {
+    case 'COMMENT':
+      return '댓글을';
+    case 'LIKE':
+      return '좋아요를';
+    default:
+      return '공지';
+  }
+};
+
+// 알람 메시지 생성 ex) "Helen님이 댓글을 남겼습니다" 형식
+export const getAlarmMessage = (alarm: Alarm) => {
+  return `${alarm.senderNickname}님이 ${alarm.postTitle} 게시글에 ${getNotificationText(alarm.alarmType)} 남겼습니다`;
+};

--- a/src/features/alarm/utils/getNotificationIcon.ts
+++ b/src/features/alarm/utils/getNotificationIcon.ts
@@ -1,0 +1,13 @@
+/**
+ * 알람 타입별 아이콘을 반환하는 함수
+ */
+export const getNotificationIcon = (type: string) => {
+  switch (type) {
+    case 'COMMENT':
+      return '💬';
+    case 'LIKE':
+      return '❤️';
+    default:
+      return '📢';
+  }
+};

--- a/src/pages/AlarmListPage/index.tsx
+++ b/src/pages/AlarmListPage/index.tsx
@@ -7,8 +7,6 @@ import PageHeader from '@/shared/layout/PageHeader';
 import { formatDate } from '@/utils/formatDate';
 import { useLocation, useNavigate } from 'react-router-dom';
 
-// 알람 데이터 타입 정의 (실제 API 응답 구조에 맞춤)
-
 const AlarmListPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
@@ -29,10 +27,7 @@ const AlarmListPage = () => {
   });
 
   const AlarmConfirmMutation = useConfirmAlarm();
-
   const alarmLength = AlarmListData?.pages[0].totalCount;
-
-  // 모든 페이지의 알람을 하나의 배열로 합치기
   const allAlarms = AlarmListData?.pages?.flatMap(page => page.alarms) || [];
 
   const handleAlarmClick = (postId: number, alarmId: number) => {
@@ -48,7 +43,6 @@ const AlarmListPage = () => {
     } catch {
       alert('존재하지 않는 알람입니다');
     }
-    navigate(`/post/${postId}`);
   };
 
   return (

--- a/src/pages/AlarmListPage/index.tsx
+++ b/src/pages/AlarmListPage/index.tsx
@@ -1,16 +1,13 @@
 import useConfirmAlarm from '@/features/alarm/hooks/useConfirmAlarm';
 import useGetAlarmList from '@/features/alarm/hooks/useGetAlarmList';
+import { getAlarmMessage } from '@/features/alarm/utils/getAlarmMessage';
+import { getNotificationIcon } from '@/features/alarm/utils/getNotificationIcon';
 import { useInfiniteScroll } from '@/shared/hooks/useInfiniteScroll';
 import PageHeader from '@/shared/layout/PageHeader';
 import { formatDate } from '@/utils/formatDate';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 // 알람 데이터 타입 정의 (실제 API 응답 구조에 맞춤)
-interface IAlarm {
-  senderNickname: string;
-  alarmType: string;
-  createdAt: string;
-}
 
 const AlarmListPage = () => {
   const navigate = useNavigate();
@@ -24,7 +21,6 @@ const AlarmListPage = () => {
     isFetchingNextPage,
     isLoading: isAlarmsLoading,
   } = useGetAlarmList(receiverId);
-  console.log(AlarmListData);
 
   const lastAlarmRef = useInfiniteScroll({
     isLoading: isFetchingNextPage,
@@ -38,35 +34,6 @@ const AlarmListPage = () => {
 
   // 모든 페이지의 알람을 하나의 배열로 합치기
   const allAlarms = AlarmListData?.pages?.flatMap(page => page.alarms) || [];
-
-  // 알람 타입별 아이콘 반환
-  const getNotificationIcon = (type: string) => {
-    switch (type) {
-      case 'COMMENT':
-        return '💬';
-      case 'LIKE':
-        return '❤️';
-      default:
-        return '📢';
-    }
-  };
-
-  // 알람 메시지 생성 ex) "Helen님이 댓글을 남겼습니다" 형식
-  const getNotificationMessage = (alarm: IAlarm) => {
-    return `${alarm.senderNickname}님이 ${getNotificationText(alarm.alarmType)} 남겼습니다`;
-  };
-
-  // 알람 타입 한글 -> 영어 변환
-  const getNotificationText = (type: string) => {
-    switch (type) {
-      case 'COMMENT':
-        return '댓글을';
-      case 'LIKE':
-        return '좋아요를';
-      default:
-        return '공지';
-    }
-  };
 
   const handleAlarmClick = (postId: number, alarmId: number) => {
     try {
@@ -123,7 +90,7 @@ const AlarmListPage = () => {
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2 mb-1">
                           <h3 className="font-semibold text-sm text-gray-900">
-                            {getNotificationMessage(alarm)}
+                            {getAlarmMessage(alarm)}
                           </h3>
 
                           <div className="w-2 h-2 bg-blue-500 rounded-full flex-shrink-0" />


### PR DESCRIPTION
# [FEATURE] 알람 메시지에 데이터 추가, 유틸 함수 분리 (#183)

## 📝 개요
알람 메시지 UI 수정 및 유틸 함수 리팩토링

## 🔗 연관된 이슈
- close #183 

## 🔄 변경사항 및 이유
피그마 화면 설계서중 알림 메시지에 `postTitle`이 보여져야 하는 것을 확인하여, UI를 수정하였습니다.
이외 알람 메시지로 변환하는 유틸 함수 및 알람 아이콘을 얻는 유틸함수를 기능 내 utils 폴더에 배치하였습니다.

## 📋 작업할 내용
- [x] UI 수정
- [x] 리팩토링 

## 🔖 기타사항

