### PR TITLE
[CHORE] 타입 중복 선언 제거 및 코드 리팩토링 (#172)

### DIFF
--- a/src/features/alarm/api/getAlarmList.ts
+++ b/src/features/alarm/api/getAlarmList.ts
@@ -1,21 +1,12 @@
 import { API_SUB_URLS_V3 } from '@/constants/apiConfig';
 import axiosInstance from '@/shared/lib/axios';
 import { IApiResponse } from '@/shared/types/ApiResponse';
+import { Alarm } from '../types/alarm';
 
 interface IGetAlarmListProps {
   receiverId: number;
   pageParam: number | null;
 }
-
-export type Alarm = {
-  id: number;
-  senderId: number;
-  postId: number;
-  senderNickname: string;
-  postTitle: string;
-  createdAt: string;
-  alarmType: string;
-};
 
 interface IGetAlarmListResponse {
   alarms: Alarm[];

--- a/src/features/alarm/components/AlarmItem.tsx
+++ b/src/features/alarm/components/AlarmItem.tsx
@@ -1,0 +1,53 @@
+import { useNavigate } from 'react-router-dom';
+import useConfirmAlarm from '../hooks/useConfirmAlarm';
+import { Alarm } from '../types/alarm';
+import { getNotificationIcon } from '../utils/getNotificationIcon';
+import { getAlarmMessage } from '../utils/getAlarmMessage';
+import { formatDate } from '@/utils/formatDate';
+
+const AlarmItem = (alarm: Alarm) => {
+  const navigate = useNavigate();
+  const AlarmConfirmMutation = useConfirmAlarm();
+  const handleAlarmClick = (postId: number, alarmId: number) => {
+    try {
+      AlarmConfirmMutation.mutate(
+        { alarmId, userId: alarm.receiverId },
+        {
+          onSuccess: () => {
+            navigate(`/post/${postId}`);
+          },
+        }
+      );
+    } catch {
+      alert('존재하지 않는 알람입니다');
+    }
+  };
+
+  return (
+    <div
+      onClick={() => handleAlarmClick(alarm.postId, alarm.id)}
+      className={`
+                  p-4 rounded-lg border cursor-pointer transition-colors
+                  bg-blue-50 border-blue-200
+                  hover:bg-gray-50
+                `}
+    >
+      <div className="flex items-start gap-3">
+        {/* 알람 아이콘 */}
+        <div className="flex-shrink-0 text-xl">{getNotificationIcon(alarm.alarmType)}</div>
+
+        {/* 알람 내용 */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <h3 className="font-semibold text-sm text-gray-900">{getAlarmMessage(alarm)}</h3>
+
+            <div className="w-2 h-2 bg-blue-500 rounded-full flex-shrink-0" />
+          </div>
+          <p className="text-xs text-gray-400 mt-1">{formatDate(alarm.createdAt)}</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AlarmItem;

--- a/src/features/alarm/types/alarm.ts
+++ b/src/features/alarm/types/alarm.ts
@@ -1,0 +1,10 @@
+export type Alarm = {
+  id: number;
+  senderId: number;
+  receiverId: number;
+  postId: number;
+  senderNickname: string;
+  postTitle: string;
+  createdAt: string;
+  alarmType: string;
+};

--- a/src/features/alarm/utils/getAlarmMessage.ts
+++ b/src/features/alarm/utils/getAlarmMessage.ts
@@ -1,4 +1,5 @@
-import { Alarm } from '../api/getAlarmList';
+import { Alarm } from '../types/alarm';
+
 /**
  * 알람 타입에 따라 한글+전치사로 변환하는 함수
  * @param type

--- a/src/features/comment/api/getCommentList.ts
+++ b/src/features/comment/api/getCommentList.ts
@@ -1,19 +1,8 @@
 import { API_SUB_URLS_V3 } from '@/constants/apiConfig';
 import axiosInstance from '@/shared/lib/axios';
 import { IApiResponse } from '@/shared/types/ApiResponse';
+import { Comment } from '../types/comment';
 
-type Comment = {
-  id: number;
-  comment: string;
-  author: Author;
-  createdAt: string;
-};
-
-type Author = {
-  userId: number;
-  nickname: string;
-  imgUrl: string;
-};
 interface ICommentListResponse {
   postId: number;
   nextCursorId: number | null;

--- a/src/features/comment/components/commentItem.tsx
+++ b/src/features/comment/components/commentItem.tsx
@@ -6,12 +6,7 @@ import useDeleteComment from '../hooks/useDeleteComment';
 import { useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '@/constants/queryKeys';
 import defaultProfileImage from '@/assets/defaultProfileImage.png';
-
-type Author = {
-  userId: number;
-  imgUrl: string;
-  nickname: string;
-};
+import { CommentAuthor } from '../types/comment';
 
 interface ICommentProps {
   postId: number;
@@ -19,7 +14,7 @@ interface ICommentProps {
   content: string;
   createdAt: string;
   isOwner: boolean;
-  author: Author;
+  author: CommentAuthor;
 }
 
 const CommentItem = (data: ICommentProps) => {

--- a/src/features/comment/types/comment.ts
+++ b/src/features/comment/types/comment.ts
@@ -1,0 +1,12 @@
+export type CommentAuthor = {
+  userId: number;
+  nickname: string;
+  imgUrl: string;
+};
+
+export type Comment = {
+  id: number;
+  comment: string;
+  author: CommentAuthor;
+  createdAt: string;
+};

--- a/src/features/post/api/getHotPosts.ts
+++ b/src/features/post/api/getHotPosts.ts
@@ -1,10 +1,10 @@
 import { API_SUB_URLS_V3 } from '@/constants/apiConfig';
 import axiosInstance from '@/shared/lib/axios';
 import { IApiResponse } from '@/shared/types/ApiResponse';
-import { Posts } from './getPostList';
+import { Post } from '../types/post';
 
 const getHotPosts = async () => {
-  const response = await axiosInstance.get<IApiResponse<Posts[]>>(`${API_SUB_URLS_V3}/posts/top`);
+  const response = await axiosInstance.get<IApiResponse<Post[]>>(`${API_SUB_URLS_V3}/posts/top`);
 
   return response.data.data;
 };

--- a/src/features/post/api/getMyPosts.ts
+++ b/src/features/post/api/getMyPosts.ts
@@ -1,28 +1,7 @@
 import { API_SUB_URLS } from '@/constants/apiConfig';
 import axiosInstance from '@/shared/lib/axios';
 import { IApiResponse } from '@/shared/types/ApiResponse';
-
-type Category = {
-  categoryId: number;
-  categoryName: string;
-};
-
-type Author = {
-  userId: number;
-  nickname: string;
-  imgUrl: string;
-};
-
-type Post = {
-  postId: number;
-  problemNumber: number;
-  title: string;
-  createdAt: string; // ISO 문자열 (예: "2025-06-10T00:21:02.664862")
-  categories: Category[];
-  author: Author;
-  commentCount: number;
-  likeCount: number;
-};
+import { Post } from '../types/post';
 
 export interface IGetMyPostsResponse {
   nextCursorId: number;

--- a/src/features/post/api/getPostDetail.ts
+++ b/src/features/post/api/getPostDetail.ts
@@ -1,17 +1,8 @@
 import { API_SUB_URLS_V3 } from '@/constants/apiConfig';
 import axiosInstance from '@/shared/lib/axios';
 import { IApiResponse } from '@/shared/types/ApiResponse';
-
-type Category = {
-  categoryId: number;
-  categoryName: string;
-};
-
-type Author = {
-  userId: number;
-  nickname: string;
-  imgUrl: string;
-};
+import { Author } from '../types/author';
+import { Category } from '../types/Category';
 
 export interface IGetPostDetailResponse {
   problemNumber: number;

--- a/src/features/post/api/getPostList.ts
+++ b/src/features/post/api/getPostList.ts
@@ -1,33 +1,12 @@
 import { API_SUB_URLS_V3 } from '@/constants/apiConfig';
 import axiosInstance from '@/shared/lib/axios';
 import { IApiResponse } from '@/shared/types/ApiResponse';
-
-export type Category = {
-  categoryId: number;
-  categoryName: string;
-};
-
-export type Author = {
-  userId: number;
-  nickname: string;
-  imgUrl: string;
-};
-
-export type Posts = {
-  postId: number;
-  problemNumber: number;
-  title: string;
-  createdAt: string;
-  categories: Category[];
-  author: Author;
-  commentCount: number;
-  likeCount: number;
-};
+import { Post } from '../types/post';
 
 export interface IGetPostListResponse {
   nextCursorId: number;
   hasNext: boolean;
-  posts: Posts[];
+  posts: Post[];
 }
 
 export interface IGetPostListProps {

--- a/src/features/post/components/HotPostItem.tsx
+++ b/src/features/post/components/HotPostItem.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect } from 'react';
 import hotIc from '@/assets/hotIc.png';
 import { useNavigate } from 'react-router-dom';
-import { Posts } from '../api/getPostList';
+import { Post } from '../types/post';
 
 interface IHotPostItemProps {
-  hotPostData: Posts[];
+  hotPostData: Post[];
 }
 
 const HotPostItem = ({ hotPostData }: IHotPostItemProps) => {

--- a/src/features/post/components/PostForm.tsx
+++ b/src/features/post/components/PostForm.tsx
@@ -8,8 +8,8 @@ import Input from '@/shared/ui/Input';
 import { convertKoreanToEnglish } from '@/utils/doMappingCategories';
 import MDEditor from '@uiw/react-md-editor';
 import { useMemo, useState } from 'react';
-import { Category } from '../api/getPostList';
 import { convertEnglishToKorean } from '@/utils/doMappingCategories';
+import { Category } from '../types/Category';
 
 export type Post = {
   problemNumber: number;

--- a/src/features/post/components/PostItem.tsx
+++ b/src/features/post/components/PostItem.tsx
@@ -1,10 +1,10 @@
 import { formatDate } from '@/utils/formatDate';
 import { useNavigate } from 'react-router-dom';
-import { Posts } from '../api/getPostList';
 import { convertEnglishCategoryToKorean } from '@/utils/doMappingCategories';
+import { Post } from '../types/post';
 
 interface IPostItemProps {
-  post: Posts;
+  post: Post;
 }
 
 const PostItem = ({ post }: IPostItemProps) => {

--- a/src/features/post/components/PostMeta.tsx
+++ b/src/features/post/components/PostMeta.tsx
@@ -6,16 +6,8 @@ import { useState } from 'react';
 import useDeletePost from '../hooks/useDeletePost';
 import { useNavigate } from 'react-router-dom';
 import defaultProfileImage from '@/assets/defaultProfileImage.png';
-
-type Author = {
-  imgUrl: string;
-  nickname: string;
-};
-
-type Category = {
-  categoryName: string;
-  categoryId: number;
-};
+import { Category } from '../types/Category';
+import { Author } from '../types/author';
 
 interface IPostMetaProps {
   isOwner: boolean;

--- a/src/features/post/types/Category.ts
+++ b/src/features/post/types/Category.ts
@@ -1,0 +1,4 @@
+export type Category = {
+  categoryId: number;
+  categoryName: string;
+};

--- a/src/features/post/types/author.ts
+++ b/src/features/post/types/author.ts
@@ -1,0 +1,5 @@
+export type Author = {
+  userId: number;
+  nickname: string;
+  imgUrl: string;
+};

--- a/src/features/post/types/post.ts
+++ b/src/features/post/types/post.ts
@@ -1,0 +1,13 @@
+import { Author } from './author';
+import { Category } from './Category';
+
+export type Post = {
+  postId: number;
+  problemNumber: number;
+  title: string;
+  createdAt: string;
+  categories: Category[];
+  author: Author;
+  commentCount: number;
+  likeCount: number;
+};

--- a/src/features/problemSet/api/getProblem.ts
+++ b/src/features/problemSet/api/getProblem.ts
@@ -1,19 +1,13 @@
 import { API_SUB_URLS } from '@/constants/apiConfig';
 import axiosInstance from '@/shared/lib/axios';
 import { IApiResponse } from '@/shared/types/ApiResponse';
-
-export interface IProblemItem {
-  problemId: number;
-  problemNumber: number;
-  title: string;
-  tier: string;
-}
+import { Problem } from '../types/problem';
 
 export interface IGetProblemSetResponse {
   date: string;
   problemSetId: number;
   isAnswered: boolean;
-  problems: IProblemItem[];
+  problems: Problem[];
 }
 
 /**

--- a/src/features/problemSet/types/problem.ts
+++ b/src/features/problemSet/types/problem.ts
@@ -1,0 +1,6 @@
+export type Problem = {
+  problemId: number;
+  problemNumber: number;
+  title: string;
+  tier: string;
+};

--- a/src/features/survey/api/registerSurvey.ts
+++ b/src/features/survey/api/registerSurvey.ts
@@ -1,16 +1,11 @@
 import { IApiResponse } from '@/shared/types/ApiResponse';
 import axiosInstance from '@/shared/lib/axios';
 import { API_SUB_URLS } from '@/constants/apiConfig';
-
-export interface IProblemSurvey {
-  problemId: number;
-  isSolved: boolean;
-  difficultyLevel: string;
-}
+import { ProblemSurvey } from '../types/problemSurvey';
 
 export interface IProblemSurveyRequest {
   problemSetId: number;
-  responses: IProblemSurvey[];
+  responses: ProblemSurvey[];
 }
 /**
  * POST) 설문 등록

--- a/src/features/survey/hooks/useRegisterSurvey.ts
+++ b/src/features/survey/hooks/useRegisterSurvey.ts
@@ -1,16 +1,11 @@
 // src/hooks/mutations/useProblemMutations.ts
 import { useMutation } from '@tanstack/react-query';
 import { registerSurvey } from '../api/registerSurvey';
-
-export interface IProblemSurvey {
-  problemId: number;
-  isSolved: boolean;
-  difficultyLevel: string;
-}
+import { ProblemSurvey } from '../types/problemSurvey';
 
 export interface IProblemSurveyRequest {
   problemSetId: number;
-  responses: IProblemSurvey[];
+  responses: ProblemSurvey[];
 }
 
 /**

--- a/src/features/survey/types/problemSurvey.ts
+++ b/src/features/survey/types/problemSurvey.ts
@@ -1,0 +1,5 @@
+export type ProblemSurvey = {
+  problemId: number;
+  isSolved: boolean;
+  difficultyLevel: string;
+};

--- a/src/features/user/api/getUserStudyStats.ts
+++ b/src/features/user/api/getUserStudyStats.ts
@@ -1,15 +1,10 @@
 import { API_SUB_URLS } from '@/constants/apiConfig';
 import axiosInstance from '@/shared/lib/axios';
 import { IApiResponse } from '@/shared/types/ApiResponse';
-
-export interface IStudyStat {
-  categoryId: number;
-  categoryName: string;
-  correctRate: number;
-}
+import { StudyStat } from '../types/studystat';
 
 export interface IStudyStatsResponse {
-  studyStats: IStudyStat[];
+  studyStats: StudyStat[];
 }
 /**
  * Get) 사용자 알고리즘 스탯 조회

--- a/src/features/user/types/studyStat.ts
+++ b/src/features/user/types/studyStat.ts
@@ -1,0 +1,5 @@
+export type StudyStat = {
+  categoryId: number;
+  categoryName: string;
+  correctRate: number;
+};

--- a/src/pages/AlarmListPage/index.tsx
+++ b/src/pages/AlarmListPage/index.tsx
@@ -1,14 +1,10 @@
-import useConfirmAlarm from '@/features/alarm/hooks/useConfirmAlarm';
+import AlarmItem from '@/features/alarm/components/AlarmItem';
 import useGetAlarmList from '@/features/alarm/hooks/useGetAlarmList';
-import { getAlarmMessage } from '@/features/alarm/utils/getAlarmMessage';
-import { getNotificationIcon } from '@/features/alarm/utils/getNotificationIcon';
 import { useInfiniteScroll } from '@/shared/hooks/useInfiniteScroll';
 import PageHeader from '@/shared/layout/PageHeader';
-import { formatDate } from '@/utils/formatDate';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 
 const AlarmListPage = () => {
-  const navigate = useNavigate();
   const location = useLocation();
   const receiverId = location.state.receiverId || undefined;
 
@@ -26,24 +22,8 @@ const AlarmListPage = () => {
     fetchNextPage,
   });
 
-  const AlarmConfirmMutation = useConfirmAlarm();
   const alarmLength = AlarmListData?.pages[0].totalCount;
   const allAlarms = AlarmListData?.pages?.flatMap(page => page.alarms) || [];
-
-  const handleAlarmClick = (postId: number, alarmId: number) => {
-    try {
-      AlarmConfirmMutation.mutate(
-        { alarmId, userId: receiverId },
-        {
-          onSuccess: () => {
-            navigate(`/post/${postId}`);
-          },
-        }
-      );
-    } catch {
-      alert('존재하지 않는 알람입니다');
-    }
-  };
 
   return (
     <div className="bg-background min-h-screen relative">
@@ -64,34 +44,8 @@ const AlarmListPage = () => {
                 const isLastAlarm = index === allAlarms.length - 1;
 
                 return (
-                  <div
-                    key={alarm.id}
-                    ref={isLastAlarm ? lastAlarmRef : null}
-                    onClick={() => handleAlarmClick(alarm.postId, alarm.id)}
-                    className={`
-                  p-4 rounded-lg border cursor-pointer transition-colors
-                  bg-blue-50 border-blue-200
-                  hover:bg-gray-50
-                `}
-                  >
-                    <div className="flex items-start gap-3">
-                      {/* 알람 아이콘 */}
-                      <div className="flex-shrink-0 text-xl">
-                        {getNotificationIcon(alarm.alarmType)}
-                      </div>
-
-                      {/* 알람 내용 */}
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2 mb-1">
-                          <h3 className="font-semibold text-sm text-gray-900">
-                            {getAlarmMessage(alarm)}
-                          </h3>
-
-                          <div className="w-2 h-2 bg-blue-500 rounded-full flex-shrink-0" />
-                        </div>
-                        <p className="text-xs text-gray-400 mt-1">{formatDate(alarm.createdAt)}</p>
-                      </div>
-                    </div>
+                  <div key={alarm.id} ref={isLastAlarm ? lastAlarmRef : null}>
+                    <AlarmItem {...alarm} />
                   </div>
                 );
               })}

--- a/src/pages/MainPage/components/TotalStudyCard/index.tsx
+++ b/src/pages/MainPage/components/TotalStudyCard/index.tsx
@@ -1,15 +1,10 @@
+import { StudyStat } from '@/features/user/types/studystat';
 import Card from '@/shared/ui/Card';
 import Spinner from '@/shared/ui/Spinner';
 import { lazy, Suspense } from 'react';
 
-interface IStudyStat {
-  categoryId: number;
-  categoryName: string;
-  correctRate: number;
-}
-
 interface ITotalStudyCardProps {
-  studyStats: IStudyStat[];
+  studyStats: StudyStat[];
 }
 
 const RadarChart = lazy(() => import('../../../../features/user/components/StudyStatsRadarChart'));

--- a/src/pages/MyPostsPage/index.tsx
+++ b/src/pages/MyPostsPage/index.tsx
@@ -20,7 +20,6 @@ const MyPostPage = () => {
   });
 
   const allPosts = myPostListData?.pages?.flatMap(page => page.posts) || [];
-  console.log(allPosts);
 
   return (
     <div className="bg-background min-h-screen relative pb-20">

--- a/src/pages/PostsPage/index.tsx
+++ b/src/pages/PostsPage/index.tsx
@@ -12,21 +12,6 @@ import { useInfiniteScroll } from '@/shared/hooks/useInfiniteScroll';
 import { useMemo, useState } from 'react';
 import { convertKoreanToEnglish } from '@/utils/doMappingCategories';
 import useGetHotPost from '@/features/post/hooks/useGetHotPost';
-interface IAuthor {
-  userId: number;
-  nickname: string;
-  imgUrl: string;
-}
-
-export interface IPostItem {
-  postId: number;
-  title: string;
-  content: string;
-  author: IAuthor;
-  countLike: number;
-  countComment: number;
-  createdAt: string;
-}
 
 const PostsPage = () => {
   const [appliedKeyword, setAppliedKeyword] = useState('');

--- a/src/pages/ProblemSolutionPage/components/ProblemDetailSection.tsx
+++ b/src/pages/ProblemSolutionPage/components/ProblemDetailSection.tsx
@@ -3,7 +3,6 @@ import { processMathHtml } from '@/features/problemSet/utils/processMathHtml';
 import { processMathText } from '@/features/problemSet/utils/processMathText';
 import { MathJax, MathJaxContext } from 'better-react-mathjax';
 import { useEffect } from 'react';
-//import { useEffect } from 'react';
 import { Fragment } from 'react/jsx-runtime';
 
 const ProblemDetailSection = (data: IGetProblemSolutionResponse) => {

--- a/src/pages/SurveyPage/index.tsx
+++ b/src/pages/SurveyPage/index.tsx
@@ -10,18 +10,12 @@ import { useRegisterSurvey } from '@/features/survey/hooks/useRegisterSurvey';
 import { useProblemSet } from '@/features/problemSet/hooks/useProblemSet';
 import { IProblemSurveyRequest } from '@/features/survey/api/registerSurvey';
 import useSubmitButton from '@/shared/hooks/useSubmitButton';
+import { Problem } from '@/features/problemSet/types/problem';
 interface ISurveyData {
   problemId: number;
   isSolved: boolean | null;
   difficultyLevel: string;
 }
-
-type Problem = {
-  problemId: number;
-  problemNumber: number;
-  title: string;
-  tier: string;
-};
 
 export interface IProblemSetResponse {
   date: string;


### PR DESCRIPTION
# [CHORE] 타입 중복 선언 제거 및 코드 리팩토링 (#172)

## 📝 개요
중복 선언되어 있는 타입을 정리하고, 기능 내 공통 타입일 경우 `types` 폴더 내 배치하여 재사용성 및 유지보수성을 높였습니다.

## 🔗 연관된 이슈
- close #172 

## 🔄 변경사항 및 이유
- 불필요한 console.log 제거
- `Post`, `Problem`, `StudyStat`, `Author`, `CommentAuthor`, `Category` 등 자주 사용되는 타입 파일 분리

## 📋 작업할 내용
- [x] 리팩토링

## 🔖 기타사항

