### PR TITLE
[FIX] 토큰 갱신 실패시 무한 요청 오류 (#186)

### DIFF
--- a/src/shared/lib/axios.ts
+++ b/src/shared/lib/axios.ts
@@ -8,16 +8,16 @@ const axiosInstance = axios.create({
 });
 
 //토큰 갱신 전용 axios 인스턴스
-// const refreshAxios = axios.create({
-//   baseURL: axiosInstance.defaults.baseURL,
-//   withCredentials: true,
-//   timeout: 5000, // 토큰 갱신은 좀 더 짧게
-// });
+const refreshAxios = axios.create({
+  baseURL: API_BASE_URL,
+  withCredentials: true,
+  timeout: 5000, // 토큰 갱신은 좀 더 짧게
+});
 
 // 토큰 갱신 함수
 const refreshToken = async () => {
   try {
-    const response = await axiosInstance.post('/api/backend/v1/auth/refresh');
+    const response = await refreshAxios.post('/api/backend/v1/auth/refresh');
 
     return response.status === 200;
   } catch {


### PR DESCRIPTION
# [FIX] 토큰 갱신 실패시 무한 요청 오류 (#186)

## 📝 개요
토큰 갱신 실패할 시 토큰 요청이 무한으로 보내지는 현상을 해결합니다.

## 🔗 연관된 이슈
- close #186 

## 🔄 변경사항 및 이유
- 토큰을 갱신할땐 기존의 인스턴스 대신 리프레쉬용 인스턴스를 사용합니다.

## 📋 작업할 내용
- [x] lib/axios.ts 파일 수정

## 🔖 기타사항
