### PR TITLE
[FEATURE] formatDate 함수 수정 및 단위 테스트 (#190)

### DIFF
--- a/src/__tests__/utils/formatDate.test.ts
+++ b/src/__tests__/utils/formatDate.test.ts
@@ -1,0 +1,134 @@
+import { formatDate } from '@/utils/formatDate';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+describe('formatDate', () => {
+  // 고정된 현재 시간 설정
+  const mockNow = new Date('2024-06-15T12:00:00Z');
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(mockNow);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('방금 전', () => {
+    it('1분 미만인 경우 "방금 전"을 반환해야 한다', () => {
+      const date = new Date(mockNow.getTime() - 30 * 1000); // 30초 전
+      expect(formatDate(date.toISOString())).toBe('방금 전');
+    });
+
+    it('정확히 0초 차이인 경우 "방금 전"을 반환해야 한다', () => {
+      expect(formatDate(mockNow.toISOString())).toBe('방금 전');
+    });
+
+    it('59초 전인 경우 "방금 전"을 반환해야 한다', () => {
+      const date = new Date(mockNow.getTime() - 59 * 1000);
+      expect(formatDate(date.toISOString())).toBe('방금 전');
+    });
+  });
+
+  describe('분 단위', () => {
+    it('1분 전인 경우 "1분 전"을 반환해야 한다', () => {
+      const date = new Date(mockNow.getTime() - 1 * 60 * 1000);
+      expect(formatDate(date.toISOString())).toBe('1분 전');
+    });
+
+    it('30분 전인 경우 "30분 전"을 반환해야 한다', () => {
+      const date = new Date(mockNow.getTime() - 30 * 60 * 1000);
+      expect(formatDate(date.toISOString())).toBe('30분 전');
+    });
+
+    it('59분 전인 경우 "59분 전"을 반환해야 한다', () => {
+      const date = new Date(mockNow.getTime() - 59 * 60 * 1000);
+      expect(formatDate(date.toISOString())).toBe('59분 전');
+    });
+  });
+
+  describe('시간 단위', () => {
+    it('1시간 전인 경우 "1시간 전"을 반환해야 한다', () => {
+      const date = new Date(mockNow.getTime() - 1 * 60 * 60 * 1000);
+      expect(formatDate(date.toISOString())).toBe('1시간 전');
+    });
+
+    it('12시간 전인 경우 "12시간 전"을 반환해야 한다', () => {
+      const date = new Date(mockNow.getTime() - 12 * 60 * 60 * 1000);
+      expect(formatDate(date.toISOString())).toBe('12시간 전');
+    });
+
+    it('23시간 전인 경우 "23시간 전"을 반환해야 한다', () => {
+      const date = new Date(mockNow.getTime() - 23 * 60 * 60 * 1000);
+      expect(formatDate(date.toISOString())).toBe('23시간 전');
+    });
+  });
+
+  describe('일 단위', () => {
+    it('1일 전인 경우 "1일 전"을 반환해야 한다', () => {
+      const date = new Date(mockNow.getTime() - 1 * 24 * 60 * 60 * 1000);
+      expect(formatDate(date.toISOString())).toBe('1일 전');
+    });
+
+    it('3일 전인 경우 "3일 전"을 반환해야 한다', () => {
+      const date = new Date(mockNow.getTime() - 3 * 24 * 60 * 60 * 1000);
+      expect(formatDate(date.toISOString())).toBe('3일 전');
+    });
+
+    it('6일 전인 경우 "6일 전"을 반환해야 한다', () => {
+      const date = new Date(mockNow.getTime() - 6 * 24 * 60 * 60 * 1000);
+      expect(formatDate(date.toISOString())).toBe('6일 전');
+    });
+  });
+
+  describe('월일 형식', () => {
+    it('7일 전인 경우 "6월 8일" 형식을 반환해야 한다', () => {
+      const date = new Date(mockNow.getTime() - 7 * 24 * 60 * 60 * 1000);
+      expect(formatDate(date.toISOString())).toBe('6월 8일');
+    });
+
+    it('1개월 전인 경우 "5월 15일" 형식을 반환해야 한다', () => {
+      const date = new Date('2024-05-15T12:00:00Z');
+      expect(formatDate(date.toISOString())).toBe('5월 15일');
+    });
+
+    it('1년 전인 경우도 올바른 월일 형식을 반환해야 한다', () => {
+      const date = new Date('2023-03-10T12:00:00Z');
+      expect(formatDate(date.toISOString())).toBe('3월 10일');
+    });
+  });
+
+  describe('경계값 테스트', () => {
+    it('정확히 1분(60초) 전인 경우 "1분 전"을 반환해야 한다', () => {
+      const date = new Date(mockNow.getTime() - 60 * 1000);
+      expect(formatDate(date.toISOString())).toBe('1분 전');
+    });
+
+    it('정확히 1시간(3600초) 전인 경우 "1시간 전"을 반환해야 한다', () => {
+      const date = new Date(mockNow.getTime() - 60 * 60 * 1000);
+      expect(formatDate(date.toISOString())).toBe('1시간 전');
+    });
+
+    it('정확히 1일(86400초) 전인 경우 "1일 전"을 반환해야 한다', () => {
+      const date = new Date(mockNow.getTime() - 24 * 60 * 60 * 1000);
+      expect(formatDate(date.toISOString())).toBe('1일 전');
+    });
+
+    it('정확히 7일 전인 경우 월일 형식을 반환해야 한다', () => {
+      const date = new Date(mockNow.getTime() - 7 * 24 * 60 * 60 * 1000);
+      expect(formatDate(date.toISOString())).toBe('6월 8일');
+    });
+  });
+
+  describe('다양한 날짜 형식 지원', () => {
+    it('ISO 8601 형식을 지원해야 한다', () => {
+      const date = new Date(mockNow.getTime() - 5 * 60 * 1000);
+      expect(formatDate(date.toISOString())).toBe('5분 전');
+    });
+
+    it('일반적인 날짜 문자열 형식을 지원해야 한다', () => {
+      const date = new Date(mockNow.getTime() - 2 * 60 * 60 * 1000);
+      expect(formatDate(date.toString())).toBe('2시간 전');
+    });
+  });
+});

--- a/src/__tests__/utils/formatDate.test.ts
+++ b/src/__tests__/utils/formatDate.test.ts
@@ -1,134 +1,50 @@
 import { formatDate } from '@/utils/formatDate';
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { vi } from 'vitest';
 
 describe('formatDate', () => {
-  // 고정된 현재 시간 설정
-  const mockNow = new Date('2024-06-15T12:00:00Z');
+  const fixedNow = new Date('2025-06-17T12:00:00+09:00');
 
-  beforeEach(() => {
+  beforeAll(() => {
     vi.useFakeTimers();
-    vi.setSystemTime(mockNow);
+    vi.setSystemTime(fixedNow);
   });
 
-  afterEach(() => {
+  afterAll(() => {
     vi.useRealTimers();
   });
 
-  describe('방금 전', () => {
-    it('1분 미만인 경우 "방금 전"을 반환해야 한다', () => {
-      const date = new Date(mockNow.getTime() - 30 * 1000); // 30초 전
-      expect(formatDate(date.toISOString())).toBe('방금 전');
-    });
-
-    it('정확히 0초 차이인 경우 "방금 전"을 반환해야 한다', () => {
-      expect(formatDate(mockNow.toISOString())).toBe('방금 전');
-    });
-
-    it('59초 전인 경우 "방금 전"을 반환해야 한다', () => {
-      const date = new Date(mockNow.getTime() - 59 * 1000);
-      expect(formatDate(date.toISOString())).toBe('방금 전');
-    });
+  it('1분 미만이면 "방금 전"을 반환해야 한다', () => {
+    const date = new Date(fixedNow.getTime() - 30 * 1000); // 30초 전
+    expect(formatDate(date.toISOString())).toBe('방금 전');
   });
 
-  describe('분 단위', () => {
-    it('1분 전인 경우 "1분 전"을 반환해야 한다', () => {
-      const date = new Date(mockNow.getTime() - 1 * 60 * 1000);
-      expect(formatDate(date.toISOString())).toBe('1분 전');
-    });
-
-    it('30분 전인 경우 "30분 전"을 반환해야 한다', () => {
-      const date = new Date(mockNow.getTime() - 30 * 60 * 1000);
-      expect(formatDate(date.toISOString())).toBe('30분 전');
-    });
-
-    it('59분 전인 경우 "59분 전"을 반환해야 한다', () => {
-      const date = new Date(mockNow.getTime() - 59 * 60 * 1000);
-      expect(formatDate(date.toISOString())).toBe('59분 전');
-    });
+  it('20분 전이면 "20분 전"을 반환해야 한다', () => {
+    const date = new Date(fixedNow.getTime() - 20 * 60 * 1000); // 20분 전
+    expect(formatDate(date.toISOString())).toBe('20분 전');
   });
 
-  describe('시간 단위', () => {
-    it('1시간 전인 경우 "1시간 전"을 반환해야 한다', () => {
-      const date = new Date(mockNow.getTime() - 1 * 60 * 60 * 1000);
-      expect(formatDate(date.toISOString())).toBe('1시간 전');
-    });
-
-    it('12시간 전인 경우 "12시간 전"을 반환해야 한다', () => {
-      const date = new Date(mockNow.getTime() - 12 * 60 * 60 * 1000);
-      expect(formatDate(date.toISOString())).toBe('12시간 전');
-    });
-
-    it('23시간 전인 경우 "23시간 전"을 반환해야 한다', () => {
-      const date = new Date(mockNow.getTime() - 23 * 60 * 60 * 1000);
-      expect(formatDate(date.toISOString())).toBe('23시간 전');
-    });
+  it('3시간 전이면 "3시간 전"을 반환해야 한다', () => {
+    const date = new Date(fixedNow.getTime() - 3 * 60 * 60 * 1000); // 3시간 전
+    expect(formatDate(date.toISOString())).toBe('3시간 전');
   });
 
-  describe('일 단위', () => {
-    it('1일 전인 경우 "1일 전"을 반환해야 한다', () => {
-      const date = new Date(mockNow.getTime() - 1 * 24 * 60 * 60 * 1000);
-      expect(formatDate(date.toISOString())).toBe('1일 전');
-    });
-
-    it('3일 전인 경우 "3일 전"을 반환해야 한다', () => {
-      const date = new Date(mockNow.getTime() - 3 * 24 * 60 * 60 * 1000);
-      expect(formatDate(date.toISOString())).toBe('3일 전');
-    });
-
-    it('6일 전인 경우 "6일 전"을 반환해야 한다', () => {
-      const date = new Date(mockNow.getTime() - 6 * 24 * 60 * 60 * 1000);
-      expect(formatDate(date.toISOString())).toBe('6일 전');
-    });
+  it('2일 전이면 "2일 전"을 반환해야 한다', () => {
+    const date = new Date(fixedNow.getTime() - 2 * 24 * 60 * 60 * 1000); // 2일 전
+    expect(formatDate(date.toISOString())).toBe('2일 전');
   });
 
-  describe('월일 형식', () => {
-    it('7일 전인 경우 "6월 8일" 형식을 반환해야 한다', () => {
-      const date = new Date(mockNow.getTime() - 7 * 24 * 60 * 60 * 1000);
-      expect(formatDate(date.toISOString())).toBe('6월 8일');
-    });
-
-    it('1개월 전인 경우 "5월 15일" 형식을 반환해야 한다', () => {
-      const date = new Date('2024-05-15T12:00:00Z');
-      expect(formatDate(date.toISOString())).toBe('5월 15일');
-    });
-
-    it('1년 전인 경우도 올바른 월일 형식을 반환해야 한다', () => {
-      const date = new Date('2023-03-10T12:00:00Z');
-      expect(formatDate(date.toISOString())).toBe('3월 10일');
-    });
+  it('7일 초과이면 "6월 10일" 형식을 반환해야 한다', () => {
+    const date = new Date('2025-06-10T08:00:00+09:00');
+    expect(formatDate(date.toISOString())).toBe('6월 10일');
   });
 
-  describe('경계값 테스트', () => {
-    it('정확히 1분(60초) 전인 경우 "1분 전"을 반환해야 한다', () => {
-      const date = new Date(mockNow.getTime() - 60 * 1000);
-      expect(formatDate(date.toISOString())).toBe('1분 전');
-    });
-
-    it('정확히 1시간(3600초) 전인 경우 "1시간 전"을 반환해야 한다', () => {
-      const date = new Date(mockNow.getTime() - 60 * 60 * 1000);
-      expect(formatDate(date.toISOString())).toBe('1시간 전');
-    });
-
-    it('정확히 1일(86400초) 전인 경우 "1일 전"을 반환해야 한다', () => {
-      const date = new Date(mockNow.getTime() - 24 * 60 * 60 * 1000);
-      expect(formatDate(date.toISOString())).toBe('1일 전');
-    });
-
-    it('정확히 7일 전인 경우 월일 형식을 반환해야 한다', () => {
-      const date = new Date(mockNow.getTime() - 7 * 24 * 60 * 60 * 1000);
-      expect(formatDate(date.toISOString())).toBe('6월 8일');
-    });
+  it('1년 전이면 "2024년 6월 17일" 형식을 반환해야 한다', () => {
+    const date = new Date('2024-06-17T08:00:00+09:00');
+    expect(formatDate(date.toISOString())).toBe('2024년 6월 17일');
   });
 
-  describe('다양한 날짜 형식 지원', () => {
-    it('ISO 8601 형식을 지원해야 한다', () => {
-      const date = new Date(mockNow.getTime() - 5 * 60 * 1000);
-      expect(formatDate(date.toISOString())).toBe('5분 전');
-    });
-
-    it('일반적인 날짜 문자열 형식을 지원해야 한다', () => {
-      const date = new Date(mockNow.getTime() - 2 * 60 * 60 * 1000);
-      expect(formatDate(date.toString())).toBe('2시간 전');
-    });
+  it('DB 포맷 "2024-06-10T08:31:21.895803" 도 정상 처리되어야 한다', () => {
+    const dateStr = '2024-06-10T08:31:21.895803'; // 실제 DB 포맷
+    expect(formatDate(dateStr)).toBe('2024년 6월 10일');
   });
 });

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,23 +1,28 @@
 /**
  *
  * @param dateString
- * @returns 6월 4일
+ * @returns '방금 전', '5분 전', '3시간 전', '2일 전', '6월 4일' 형식
  */
 export const formatDate = (dateString: string) => {
   const date = new Date(dateString);
   const now = new Date();
-  const diffInHours = Math.floor((now.getTime() - date.getTime()) / (1000 * 60 * 60));
+  const diffMs = now.getTime() - date.getTime();
+  const diffMinutes = Math.floor(diffMs / (1000 * 60));
+  const diffHours = Math.floor(diffMinutes / 60);
+  const diffDays = Math.floor(diffHours / 24);
 
-  if (diffInHours < 1) {
+  if (diffMinutes < 1) {
     return '방금 전';
-  } else if (diffInHours < 24) {
-    return `${diffInHours}시간 전`;
-  } else if (diffInHours < 24 * 7) {
-    return `${Math.floor(diffInHours / 24)}일 전`;
+  } else if (diffMinutes < 60) {
+    return `${diffMinutes}분 전`;
+  } else if (diffHours < 24) {
+    return `${diffHours}시간 전`;
+  } else if (diffDays < 7) {
+    return `${diffDays}일 전`;
   } else {
-    return date.toLocaleDateString('ko-KR', {
-      month: 'short',
-      day: 'numeric',
-    });
+    return new Intl.DateTimeFormat('ko-KR', {
+      month: 'long', // '6월'
+      day: 'numeric', // '4일'
+    }).format(date);
   }
 };

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,7 +1,7 @@
 /**
  *
  * @param dateString
- * @returns '방금 전', '5분 전', '3시간 전', '2일 전', '6월 4일' 형식
+ * @returns '방금 전', '5분 전', '3시간 전', '2일 전', '6월 4일', '2025년 6월 4일' 형식
  */
 export const formatDate = (dateString: string) => {
   const date = new Date(dateString);
@@ -20,9 +20,20 @@ export const formatDate = (dateString: string) => {
   } else if (diffDays < 7) {
     return `${diffDays}일 전`;
   } else {
-    return new Intl.DateTimeFormat('ko-KR', {
-      month: 'long', // '6월'
-      day: 'numeric', // '4일'
-    }).format(date);
+    // 올해가 아니면 연도도 포함
+    const isThisYear = date.getFullYear() === now.getFullYear();
+
+    if (isThisYear) {
+      return new Intl.DateTimeFormat('ko-KR', {
+        month: 'long',
+        day: 'numeric',
+      }).format(date);
+    } else {
+      return new Intl.DateTimeFormat('ko-KR', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      }).format(date);
+    }
   }
 };


### PR DESCRIPTION
# [FEATURE] formatDate 함수 수정 및 테스트 (#190)

## 📝 개요
`formatDate` 함수의 날짜 포맷을 개선하였습니다.

## 🔗 연관된 이슈
- closes #190 

## 🔄 변경사항 및 이유
### `formatDate` 기준 수정 
- 1분 이내 : 방금 전 
- 1시간 이내 : ~분 전
- 24시간 이내 : ~시간 전
- 7일 이내 : ~일 전
- 1년 이내 : ~월 ~일
- 그 외 : ~년 ~월 ~일

## 📋 작업할 내용
- [x] 날짜 포맷 기준 정의
- [x] `formatDate` 함수 반영
- [x] 단위 테스트

## 🔖 기타사항
