### PR TITLE
[FIX] 영어 길게 입력시 줄 바꾸기가 안 되고 ui 깨지는 현상 수정 (#197)

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,6 +3,8 @@
 *::before,
 *::after {
   box-sizing: border-box;
+  word-break: break-word;
+  overflow-wrap: break-word;
 }
 
 /* 기본 여백 제거 */


### PR DESCRIPTION
# [FIX] 영어 길게 입력시 줄 바꾸기가 안 되고 ui 깨지는 현상 수정 (#197)

## 📝 개요
한글의 경우 길게 입력하면 자동으로 줄 바꿈이 되지만 영어의 경우 UI가 깨지는 현상이 있었습니다.

## 🔗 연관된 이슈
- close #197 

## 🔄 변경사항 및 이유
- `global.css`에  `word-break: break-word;` `overflow-wrap: break-word;` 추가

## 📋 작업할 내용
- [x] css 속성 추가

## 🔖 기타사항

