### PR TITLE
[FEATURE] 게시글 작성 시 helper text 보이도록 수정 (#199)

### DIFF
--- a/src/features/post/components/PostForm.tsx
+++ b/src/features/post/components/PostForm.tsx
@@ -10,6 +10,7 @@ import MDEditor from '@uiw/react-md-editor';
 import { useMemo, useState } from 'react';
 import { convertEnglishToKorean } from '@/utils/doMappingCategories';
 import { Category } from '../types/Category';
+import Helpertext from '@/shared/ui/Helpertext';
 
 export type Post = {
   problemNumber: number;
@@ -129,6 +130,7 @@ const PostForm = ({
       <div className="mt-4">
         <label className="mt-2">제목</label>
         <Input value={title} onChange={titleOnChange} className="w-full" />
+        <div className="h-4 mt-1">{titleErr && <Helpertext text={titleErr} />}</div>
       </div>
 
       <div className="mt-4">
@@ -139,6 +141,7 @@ const PostForm = ({
           height={600}
         />
       </div>
+      <div className="h-4 mt-1">{markdownErr && <Helpertext text={markdownErr} />}</div>
 
       <div className="mt-6 text-center">
         <Button onClick={handleSubmit} disabled={isDisabled}>


### PR DESCRIPTION
# [FEATURE] 게시글 작성 시 helper text 보이도록 수정 (#199)

## 📝 개요
제목, 마크다운 등의 컨텐츠에 유효성 검사 결과인 helper text가 보여지도록 구현합니다.

## 🔗 연관된 이슈
- close #199 

## 🔄 변경사항 및 이유
- helper text 렌더링

## 📋 작업할 내용
- [ ] helper text 렌더링

## 🔖 기타사항
