### PR TITLE
[HOTFIX] 게시판 글자 수 제한 확장 (#220)

### DIFF
--- a/src/features/post/components/PostForm.tsx
+++ b/src/features/post/components/PostForm.tsx
@@ -85,7 +85,8 @@ const PostForm = ({
   // 마크다운 유효성 검사
   const markdownErr = useMemo(() => {
     if (!content) return '내용을 입력해주세요';
-    if (content.length < 1 || content.length > 3000) return '게시글은 최대 3000자 작성 가능합니다';
+    if (content.length < 1 || content.length > 10000)
+      return '게시글은 최대 10,000자까지 작성 가능합니다';
 
     return null;
   }, [content]);


### PR DESCRIPTION
# [HOTFIX] 게시판 글자 수 제한 확장 (#220)

## 📝 개요
사용자 피드백에 따라, 게시판의 글자 수 제한을 확장합니다.

## 🔗 연관된 이슈
- closes #220 

## 🔄 변경사항 및 이유
- 사용자 피드백에 따라 글자 수 제한을 10,000자로 확장합니다. 

## 📋 작업할 내용
- [x] 글자 수 유효성 검사 변경

## 🔖 기타사항