### PR TITLE
[HOTFIX] 문제 풀이, 알고리즘, 요약 부분 마크다운 렌더링으로 변경 (#222)

### DIFF
--- a/src/pages/ProblemSolutionPage/components/ProblemSolutionSection.tsx
+++ b/src/pages/ProblemSolutionPage/components/ProblemSolutionSection.tsx
@@ -81,15 +81,15 @@ const ProblemSolutionSection = ({
     <section className="max-w-2xl mx-auto p-6 bg-surface rounded-lg shadow-md space-y-6 mb-30">
       <h2 className="text-xl font-bold mb-4">| 문제 요약</h2>
       <p className="whitespace-pre-line break-words overflow-wrap-anywhere  leading-loose">
-        {formatCode(problemCheck)}
+        <MDEditor.Markdown source={problemCheck} />
       </p>
       <h2 className="text-xl font-bold mb-4 ">| 알고리즘</h2>
       <p className="whitespace-pre-line break-words overflow-wrap-anywhere  leading-loose">
-        {formatCode(algorithm)}
+        <MDEditor.Markdown source={formatProblemSolving(algorithm)} />
       </p>
       <h2 className="text-xl font-bold mb-4">| 풀이</h2>
       <p className="whitespace-pre-line break-words overflow-wrap-anywhere leading-loose">
-        {formatProblemSolving(problemSolving)}
+        <MDEditor.Markdown source={formatProblemSolving(problemSolving)} />
       </p>
       <div>
         <h2 className="text-xl font-bold mb-4">| 솔루션 코드</h2>


### PR DESCRIPTION
# [HOTFIX] 문제 풀이, 알고리즘, 요약 부분 마크다운 렌더링으로 변경 (#222)

## 📝 개요
LLM 해설 데이터 이슈로 기존 줄글 형식에서 마크다운으로 변경하였습니다.

## 🔗 연관된 이슈
- closes #222 

## 🔄 변경사항 및 이유
- 마크다운으로 변경

## 📋 작업할 내용
- [ ] 마크다운 렌더링으로 변경

## 🔖 기타사항

