### PR TITLE
[FEATURE] 챗봇 API 연결 및 구현 (#224)

### DIFF
--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -50,7 +50,7 @@ const Router = () => {
                 <Route path="/post/:id/edit" element={<EditPostPage />} />
                 <Route path="/my-posts" element={<MyPostPage />} />
                 <Route path="/new-chat" element={<CreateChatbotPage />} />
-                <Route path="/chatbot" element={<ChattingPage />} />
+                <Route path="/chatbot/:id" element={<ChattingPage />} />
               </Route>
             </Route>
           </Routes>

--- a/src/constants/apiConfig.ts
+++ b/src/constants/apiConfig.ts
@@ -4,3 +4,4 @@ export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localho
 /** API SUB URL입니다. */
 export const API_SUB_URLS = '/api/backend/v1';
 export const API_SUB_URLS_V3 = '/api/backend/v3';
+export const API_SUB_URLS_V2 = '/api/backend/v2';

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -29,4 +29,7 @@ export const queryKeys = {
   alarm: {
     all: ['alarms'] as const,
   },
+  chatbot: {
+    all: ['chatbots'] as const,
+  },
 };

--- a/src/features/chatbot/api/createSession.ts
+++ b/src/features/chatbot/api/createSession.ts
@@ -1,0 +1,22 @@
+import { API_SUB_URLS_V2 } from '@/constants/apiConfig';
+import axiosInstance from '@/shared/lib/axios';
+
+export interface ICreateSessionRequest {
+  problemNumber: number;
+  language: string;
+  mode: string; // feedback 또는 interview,
+  userCode: string;
+}
+
+/**
+ * 챗봇 채팅방 입장 전 세션을 생성하는 api입니다.
+ * @param data
+ * @returns
+ */
+const createSession = async (data: ICreateSessionRequest) => {
+  const response = await axiosInstance.post(`${API_SUB_URLS_V2}/chat/init`, data);
+
+  return response.data.data;
+};
+
+export default createSession;

--- a/src/features/chatbot/api/sendMessage.ts
+++ b/src/features/chatbot/api/sendMessage.ts
@@ -12,9 +12,12 @@ export interface ISendMessageRequest {
  * @returns
  */
 const sendMessage = async (data: ISendMessageRequest) => {
-  const response = await axiosInstance.post(`${API_SUB_URLS_V2}/chat/session/${data.sessionId}`, {
-    content: data.content,
-  });
+  const response = await axiosInstance.post(
+    `${API_SUB_URLS_V2}/chat/session/${data.sessionId}/followup`,
+    {
+      content: data.content,
+    }
+  );
 
   return response.data.data;
 };

--- a/src/features/chatbot/api/sendMessage.ts
+++ b/src/features/chatbot/api/sendMessage.ts
@@ -1,0 +1,22 @@
+import { API_SUB_URLS_V2 } from '@/constants/apiConfig';
+import axiosInstance from '@/shared/lib/axios';
+
+export interface ISendMessageRequest {
+  sessionId: number;
+  content: string;
+}
+
+/**
+ *  사용자에게 메시지를 전송하는 api
+ * @param data (sessionId, content)
+ * @returns
+ */
+const sendMessage = async (data: ISendMessageRequest) => {
+  const response = await axiosInstance.post(`${API_SUB_URLS_V2}/chat/session/${data.sessionId}`, {
+    content: data.content,
+  });
+
+  return response.data.data;
+};
+
+export default sendMessage;

--- a/src/features/chatbot/api/startSession.ts
+++ b/src/features/chatbot/api/startSession.ts
@@ -9,7 +9,7 @@ export interface IStartSessionRequest {
 }
 
 const startSession = async (data: IStartSessionRequest) => {
-  const response = await axiosInstance.post(`${API_SUB_URLS_V2}/chat/session`, data);
+  const response = await axiosInstance.post(`${API_SUB_URLS_V2}/chat/init`, data);
 
   return response.data.data;
 };

--- a/src/features/chatbot/api/startSession.ts
+++ b/src/features/chatbot/api/startSession.ts
@@ -1,15 +1,11 @@
 import { API_SUB_URLS_V2 } from '@/constants/apiConfig';
 import axiosInstance from '@/shared/lib/axios';
 
-export interface IStartSessionRequest {
-  problemNumber: number;
-  language: string;
-  mode: string; // feedback 또는 interview,
-  userCode: string;
-}
-
-const startSession = async (data: IStartSessionRequest) => {
-  const response = await axiosInstance.post(`${API_SUB_URLS_V2}/chat/init`, data);
+/***
+ * 채팅방 세션 시작 api 호출
+ */
+const startSession = async (sessionId: number) => {
+  const response = await axiosInstance.post(`${API_SUB_URLS_V2}/chat/session/${sessionId}/start`);
 
   return response.data.data;
 };

--- a/src/features/chatbot/api/startSession.ts
+++ b/src/features/chatbot/api/startSession.ts
@@ -1,0 +1,17 @@
+import { API_SUB_URLS_V2 } from '@/constants/apiConfig';
+import axiosInstance from '@/shared/lib/axios';
+
+export interface IStartSessionRequest {
+  problemNumber: number;
+  language: string;
+  mode: string; // feedback 또는 interview,
+  userCode: string;
+}
+
+const startSession = async (data: IStartSessionRequest) => {
+  const response = await axiosInstance.post(`${API_SUB_URLS_V2}/chat/session`, data);
+
+  return response.data.data;
+};
+
+export default startSession;

--- a/src/features/chatbot/hooks/useCreateSession.ts
+++ b/src/features/chatbot/hooks/useCreateSession.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query';
+import createSession, { ICreateSessionRequest } from '../api/createSession';
+
+const useCreateSession = () => {
+  return useMutation({
+    mutationFn: (data: ICreateSessionRequest) => createSession(data),
+  });
+};
+export default useCreateSession;

--- a/src/features/chatbot/hooks/useSendMessage.ts
+++ b/src/features/chatbot/hooks/useSendMessage.ts
@@ -1,0 +1,10 @@
+import { useMutation } from '@tanstack/react-query';
+import sendMessage, { ISendMessageRequest } from '../api/sendMessage';
+
+const useSendMessage = () => {
+  return useMutation({
+    mutationFn: (data: ISendMessageRequest) => sendMessage(data),
+  });
+};
+
+export default useSendMessage;

--- a/src/features/chatbot/hooks/useStartSession.ts
+++ b/src/features/chatbot/hooks/useStartSession.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query';
+import startSession, { IStartSessionRequest } from '../api/startSession';
+
+const useStartSession = () => {
+  return useMutation({
+    mutationFn: (data: IStartSessionRequest) => startSession(data),
+  });
+};
+export default useStartSession;

--- a/src/features/chatbot/hooks/useStartSession.ts
+++ b/src/features/chatbot/hooks/useStartSession.ts
@@ -1,9 +1,9 @@
 import { useMutation } from '@tanstack/react-query';
-import startSession, { IStartSessionRequest } from '../api/startSession';
+import startSession from '../api/startSession';
 
 const useStartSession = () => {
   return useMutation({
-    mutationFn: (data: IStartSessionRequest) => startSession(data),
+    mutationFn: (sessionId: number) => startSession(sessionId),
   });
 };
 export default useStartSession;

--- a/src/pages/ChattingPage/index.tsx
+++ b/src/pages/ChattingPage/index.tsx
@@ -46,6 +46,7 @@ const ChattingPage = () => {
   const [isLoading, setIsLoading] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const mode = useLocation().state?.mode;
+  const code = useLocation().state?.code;
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });

--- a/src/pages/ChattingPage/index.tsx
+++ b/src/pages/ChattingPage/index.tsx
@@ -56,7 +56,6 @@ const ChattingPage = () => {
     try {
       setIsLoading(true);
 
-      // 초기 코드가 있으면 사용자 메시지로 추가
       if (!initialCode) {
         alert('잘못된 경로입니다');
         navigate('/new-chat');
@@ -246,7 +245,6 @@ const ChattingPage = () => {
           console.error('Failed to start session:', error);
         }
       } else if (!id) {
-        // sessionId가 없으면 기본 메시지들 사용
         alert('잘못된 경로입니다');
         navigate('/new-chat');
       }

--- a/src/pages/CreateChatbotPage/index.tsx
+++ b/src/pages/CreateChatbotPage/index.tsx
@@ -48,9 +48,11 @@ const CreateChatbotPage = () => {
   const { isDisabled, buttonText } = useSubmitButton({ isLoading, submitErr });
 
   // 챗봇 모드 데이터 처리
-  const convertModeText = (mode: string) => {
+  const convertModeText = (mode: string | undefined) => {
     if (mode === '내 코드 피드백') return 'feedback';
     if (mode === '라이브 코딩 면접 대비') return 'interview';
+
+    return '';
   };
 
   const handleSubmit = async () => {
@@ -65,17 +67,17 @@ const CreateChatbotPage = () => {
 
     setIsLoading(true);
     try {
-      // 1. api 호출
-      // await startSessionMutation.mutate({
-      //   problemNumber: Number(problemNumber),
-      //   language: selectedLanguage,
-      //   mode: selectedMode,
-      //   userCode: code,
-      // });
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      //1. api 호출
+      await startSessionMutation.mutate({
+        problemNumber: Number(problemNumber),
+        language: selectedLanguage,
+        mode: convertModeText(selectedMode),
+        userCode: code,
+      });
+      //await new Promise(resolve => setTimeout(resolve, 1000));
       // 2. SSE 연결
       alert('AI 챗봇이 시작되었습니다!');
-      navigate(`/chatbot/${2}`, { state: { mode: selectedMode } });
+      //navigate(`/chatbot/${2}`, { state: { mode: selectedMode } });
     } catch {
       alert('백준에 존재하지 않는 문제 번호입니다.');
     } finally {

--- a/src/pages/CreateChatbotPage/index.tsx
+++ b/src/pages/CreateChatbotPage/index.tsx
@@ -68,16 +68,19 @@ const CreateChatbotPage = () => {
     setIsLoading(true);
     try {
       //1. api 호출
-      await startSessionMutation.mutate({
-        problemNumber: Number(problemNumber),
-        language: selectedLanguage,
-        mode: convertModeText(selectedMode),
-        userCode: code,
-      });
-      //await new Promise(resolve => setTimeout(resolve, 1000));
+      await startSessionMutation.mutate(
+        {
+          problemNumber: Number(problemNumber),
+          language: selectedLanguage,
+          mode: convertModeText(selectedMode),
+          userCode: code,
+        },
+        {
+          onSuccess: data =>
+            navigate(`/chatbot/${data.sessionId}`, { state: { mode: selectedMode, code: code } }),
+        }
+      );
       // 2. SSE 연결
-      alert('AI 챗봇이 시작되었습니다!');
-      //navigate(`/chatbot/${2}`, { state: { mode: selectedMode } });
     } catch {
       alert('백준에 존재하지 않는 문제 번호입니다.');
     } finally {

--- a/src/pages/CreateChatbotPage/index.tsx
+++ b/src/pages/CreateChatbotPage/index.tsx
@@ -36,8 +36,8 @@ const CreateChatbotPage = () => {
   const codeError = useMemo(() => {
     if (!code) return '코드를 입력해주세요.';
 
-    if (code.length > 2000) {
-      return '2000자까지 입력가능합니다.';
+    if (code.length > 10000) {
+      return '최대 10000자까지 입력가능합니다.';
     }
 
     return null;
@@ -65,6 +65,7 @@ const CreateChatbotPage = () => {
 
     setIsLoading(true);
     try {
+      // api 호출
       // await startSessionMutation.mutate({
       //   problemNumber: Number(problemNumber),
       //   language: selectedLanguage,
@@ -74,7 +75,7 @@ const CreateChatbotPage = () => {
       await new Promise(resolve => setTimeout(resolve, 1000));
       alert('AI 챗봇이 시작되었습니다!');
 
-      navigate('/chatbot', { state: { mode: selectedMode } });
+      navigate(`/chatbot/${2}`, { state: { mode: selectedMode } });
     } catch {
       alert('백준에 존재하지 않는 문제 번호입니다.');
     } finally {
@@ -167,7 +168,7 @@ const CreateChatbotPage = () => {
             className="w-full h-80 px-4 py-3 border border-gray-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono text-sm resize-none"
           />
           <div className="flex justify-between items-center mt-2">
-            <span className="text-xs text-gray-500">{code.length}/2000</span>
+            <span className="text-xs text-gray-500">{code.length}/10000</span>
           </div>
         </div>
 

--- a/src/pages/CreateChatbotPage/index.tsx
+++ b/src/pages/CreateChatbotPage/index.tsx
@@ -65,7 +65,7 @@ const CreateChatbotPage = () => {
 
     setIsLoading(true);
     try {
-      // api 호출
+      // 1. api 호출
       // await startSessionMutation.mutate({
       //   problemNumber: Number(problemNumber),
       //   language: selectedLanguage,
@@ -73,8 +73,8 @@ const CreateChatbotPage = () => {
       //   userCode: code,
       // });
       await new Promise(resolve => setTimeout(resolve, 1000));
+      // 2. SSE 연결
       alert('AI 챗봇이 시작되었습니다!');
-
       navigate(`/chatbot/${2}`, { state: { mode: selectedMode } });
     } catch {
       alert('백준에 존재하지 않는 문제 번호입니다.');

--- a/src/pages/CreateChatbotPage/index.tsx
+++ b/src/pages/CreateChatbotPage/index.tsx
@@ -1,3 +1,4 @@
+import useStartSession from '@/features/chatbot/hooks/useStartSession';
 import useInput from '@/shared/hooks/useInput';
 import useSubmitButton from '@/shared/hooks/useSubmitButton';
 import BottomNav from '@/shared/layout/BottomNav';
@@ -12,6 +13,7 @@ const CreateChatbotPage = () => {
   const [selectedLanguage, setSelectedLanguage] = useState('C++');
   const [selectedMode, setSelectedMode] = useState('라이브 코딩 면접 대비');
   const { value: code, onChange: onChangeCode } = useInput('');
+  const startSessionMutation = useStartSession();
 
   const [isLoading, setIsLoading] = useState(false);
 
@@ -45,13 +47,30 @@ const CreateChatbotPage = () => {
   const submitErr = problemNumberError || codeError;
   const { isDisabled, buttonText } = useSubmitButton({ isLoading, submitErr });
 
+  // 챗봇 모드 데이터 처리
+  const convertModeText = (mode: string) => {
+    if (mode === '내 코드 피드백') return 'feedback';
+    if (mode === '라이브 코딩 면접 대비') return 'interview';
+  };
+
   const handleSubmit = async () => {
     if (submitErr) return;
 
-    console.log({ problemNumber, selectedLanguage, selectedMode, code });
+    console.log({
+      problemNumber: Number(problemNumber),
+      language: selectedLanguage,
+      mode: convertModeText(selectedMode),
+      userCode: code,
+    });
 
     setIsLoading(true);
     try {
+      // await startSessionMutation.mutate({
+      //   problemNumber: Number(problemNumber),
+      //   language: selectedLanguage,
+      //   mode: selectedMode,
+      //   userCode: code,
+      // });
       await new Promise(resolve => setTimeout(resolve, 1000));
       alert('AI 챗봇이 시작되었습니다!');
 
@@ -87,7 +106,7 @@ const CreateChatbotPage = () => {
         <div>
           <label className="block text-lg font-medium text-gray-900 mb-3">언어 선택</label>
           <div className="flex gap-3">
-            {['C++', 'JAVA', 'Python'].map(lang => (
+            {['c++', 'java', 'python'].map(lang => (
               <button
                 key={lang}
                 onClick={() => setSelectedLanguage(lang)}

--- a/src/pages/CreateChatbotPage/index.tsx
+++ b/src/pages/CreateChatbotPage/index.tsx
@@ -1,4 +1,4 @@
-import useStartSession from '@/features/chatbot/hooks/useStartSession';
+import useCreateSession from '@/features/chatbot/hooks/useCreateSession';
 import useInput from '@/shared/hooks/useInput';
 import useSubmitButton from '@/shared/hooks/useSubmitButton';
 import BottomNav from '@/shared/layout/BottomNav';
@@ -13,7 +13,7 @@ const CreateChatbotPage = () => {
   const [selectedLanguage, setSelectedLanguage] = useState('C++');
   const [selectedMode, setSelectedMode] = useState('라이브 코딩 면접 대비');
   const { value: code, onChange: onChangeCode } = useInput('');
-  const startSessionMutation = useStartSession();
+  const createSessionMutation = useCreateSession();
 
   const [isLoading, setIsLoading] = useState(false);
 
@@ -68,7 +68,7 @@ const CreateChatbotPage = () => {
     setIsLoading(true);
     try {
       //1. api 호출
-      await startSessionMutation.mutate(
+      await createSessionMutation.mutate(
         {
           problemNumber: Number(problemNumber),
           language: selectedLanguage,


### PR DESCRIPTION
# [FEATURE] 챗봇 API 연결 및 구현 (#224)

## 📝 개요
챗봇 페이지 내 유저가 챗봇 채팅방 개설시 sessionId, code, mode 기반으로
챗봇 대화를 시작하며 요청 및 응답을 주고 받습니다.

## 🔗 연관된 이슈
- closes #224 

## 🔄 변경사항 및 이유
- 챗봇 생성 시 userCode를 라우팅 state로 전달하도록 수정
- 챗봇 채팅방 내 초기 데이터 유저가 입력한 코드로 초기화

## 📋 작업할 내용
- [X] 세션 생성 로직 구현
- [X] 세션 시작, 후속 질문 시 SSE 스트리밍(text/event-stream)으로 서버 응답 실시간 처리 로직 구현
- [X] 스트림을 읽어 청크 단위로 메시지 업데이트하는 로직 구현
- [X] 로딩, 에러 핸들링

## 🔖 기타사항
- 현재 fetch 방식으로 api 호출이 구현되어 있어,  401에러 (토큰 만료) 발생시 처리하는 로직을 구현하고자 합니다.
- 비즈니스 로직 분리가 필요합니다.
- 엣지 케이스에 대한 QA가 필요합니다.
