### PR TITLE
[FIX] fetch에서의 토큰 리프레쉬 로직 구현 (#224)

### DIFF
--- a/src/pages/ChattingPage/index.tsx
+++ b/src/pages/ChattingPage/index.tsx
@@ -302,13 +302,13 @@ const ChattingPage = () => {
         return true;
       } else {
         // 리프레시 실패 시 로그인 페이지로 리다이렉트
-        //navigate('/');
+        navigate('/');
 
         return false;
       }
     } catch (error) {
       console.error('Token refresh failed:', error);
-      //navigate('/');
+      navigate('/');
 
       return false;
     }

--- a/src/pages/ChattingPage/index.tsx
+++ b/src/pages/ChattingPage/index.tsx
@@ -1,4 +1,4 @@
-import { API_BASE_URL, API_SUB_URLS_V2 } from '@/constants/apiConfig';
+import { API_BASE_URL, API_SUB_URLS, API_SUB_URLS_V2 } from '@/constants/apiConfig';
 import ChatbotSystemMessage from '@/features/chatbot/components/ChatbotSystemMessage';
 import useInput from '@/shared/hooks/useInput';
 import BottomNav from '@/shared/layout/BottomNav';
@@ -79,8 +79,7 @@ const ChattingPage = () => {
 
       setMessages(prev => [...prev, botMessage]);
 
-      // 첫 응답을 위한 API 호출 (POST 요청)
-      const response = await fetch(
+      const response = await fetchStreamWithAuth(
         `${API_BASE_URL}${API_SUB_URLS_V2}/chat/session/${sessionId}/start`,
         {
           method: 'POST',
@@ -160,7 +159,7 @@ const ChattingPage = () => {
       setMessages(prev => [...prev, botMessage]);
 
       // /followup API 호출 (POST 요청)
-      const response = await fetch(
+      const response = await fetchStreamWithAuth(
         `${API_BASE_URL}${API_SUB_URLS_V2}/chat/session/${sessionId}/followup`,
         {
           method: 'POST',
@@ -289,6 +288,54 @@ const ChattingPage = () => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       handleSendMessage();
+    }
+  };
+
+  const refreshToken = async (): Promise<boolean> => {
+    try {
+      const response = await fetch(`${API_BASE_URL}${API_SUB_URLS}/auth/refresh`, {
+        method: 'POST',
+        credentials: 'include',
+      });
+
+      if (response.ok) {
+        return true;
+      } else {
+        // 리프레시 실패 시 로그인 페이지로 리다이렉트
+        //navigate('/');
+
+        return false;
+      }
+    } catch (error) {
+      console.error('Token refresh failed:', error);
+      //navigate('/');
+
+      return false;
+    }
+  };
+
+  // 스트리밍 응답 처리를 위한 401 에러 핸들링 함수
+  const fetchStreamWithAuth = async (url: string, options: RequestInit = {}): Promise<Response> => {
+    try {
+      const response = await fetch(url, options);
+
+      if (response.status === 401) {
+        // 토큰 리프레시 시도
+        const refreshSuccess = await refreshToken();
+
+        if (refreshSuccess) {
+          // 리프레시 성공 시 원래 요청 재시도
+          return await fetch(url, options);
+        } else {
+          // 리프레시 실패 시 에러 throw
+          throw new Error('Authentication failed');
+        }
+      }
+
+      return response;
+    } catch (error) {
+      console.error('Fetch with auth failed:', error);
+      throw error;
     }
   };
 


### PR DESCRIPTION
# [FIX] fetch에서의 토큰 리프레쉬 로직 구현 (#224)

## 📝 개요
이전의 axios instance를 통해 401 에러 발생 시 토큰이 자동으로 리프레쉬 되도록 구현했지만
SSE 스트리밍에서는 axios를 사용할 수 없고, 따라서 fetch에서 사용할 리프레쉬 로직을 구현하였습니다.

## 🔗 연관된 이슈
- #224

## 🔄 변경사항 및 이유
- 함수를 책임에 맞게 분리했습니다. fetch 하다 401 에러 발생 시 -> `refreshToken` 함수 호출
- `refreshToken` 함수 구현

## 📋 작업할 내용
- [x] 리프레쉬 로직 구현 및 테스트

