### PR TITLE
[ENHANCEMENT] 대화 이력 선택 - 리렌더링 최적화 (#230)

### DIFF
--- a/src/features/session/components/SessionItem.tsx
+++ b/src/features/session/components/SessionItem.tsx
@@ -3,6 +3,7 @@ import { ChatSession } from '../types/chatSession';
 import feedbackIc from '@/assets/feedbackIc.svg';
 import interviewIc from '@/assets/interviewIc.svg';
 import { useNavigate } from 'react-router-dom';
+import { memo } from 'react';
 
 interface ISessionItemProps {
   session: ChatSession;
@@ -53,4 +54,4 @@ const SessionItem = ({ session, isSelected, onSelect, isSelectionMode }: ISessio
   );
 };
 
-export default SessionItem;
+export default memo(SessionItem);

--- a/src/pages/SessionPage/index.tsx
+++ b/src/pages/SessionPage/index.tsx
@@ -6,7 +6,7 @@ import { useInfiniteScroll } from '@/shared/hooks/useInfiniteScroll';
 import useModal from '@/shared/hooks/useModal';
 import PageHeader from '@/shared/layout/PageHeader';
 import ConfirmModal from '@/shared/ui/ConfirmModal';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 const SessionPage = () => {
   const [isSelectionMode, setIsSelectionMode] = useState(false);
@@ -30,15 +30,18 @@ const SessionPage = () => {
   const allSessions = SessionListData?.pages?.flatMap(page => page.chatSessions) || [];
 
   // 단일 선택
-  const handleSelectSession = (sessionId: number) => {
-    const newSelected = new Set(selectedSessions);
-    if (newSelected.has(sessionId)) {
-      newSelected.delete(sessionId);
-    } else {
-      newSelected.add(sessionId);
-    }
-    setSelectedSessions(newSelected);
-  };
+  const handleSelectSession = useCallback((sessionId: number) => {
+    setSelectedSessions(prev => {
+      const newSelected = new Set(prev);
+      if (newSelected.has(sessionId)) {
+        newSelected.delete(sessionId);
+      } else {
+        newSelected.add(sessionId);
+      }
+
+      return newSelected;
+    });
+  }, []);
 
   // 전체 선택
   const handleSelectAll = () => {


### PR DESCRIPTION
# [CHORE] 대화 이력 선택 - 리렌더링 최적화 (#230)

## 📝 개요
대화 이력 항목을 클릭 시 전체 페이지가 리렌더링 되는 현상을 개선하였습니다.

## 🔗 연관된 이슈
- closes #230 

## 🔄 변경사항 및 이유
- `SessionItem` 컴포넌트 memo로 감싸 메모이제이션
- `SessionItem` 컴포넌트의 `onSelect` prop 때문에 리렌더링 되는 것을 방지하기 위해 useCallback으로 감싸 최적화

## 📋 작업할 내용
- [x] 리렌더링 최적화

## 🔖 기타사항

## 🔗 참고 자료
최적화 과정은 아래의 블로그에 기록해두었습니다🙇🏻‍♀️

https://hyemmimi.tistory.com/33