### PR TITLE
[FIX] 채팅 기록 렌더링 시 마크다운 줄바꿈으로 포맷 (#236)

### DIFF
--- a/src/pages/ChattingPage/index.tsx
+++ b/src/pages/ChattingPage/index.tsx
@@ -126,6 +126,7 @@ const ChattingPage = () => {
 
           const chunk = decoder.decode(value, { stream: true });
           const lines = chunk.split('\n');
+          console.log(lines);
 
           for (const line of lines) {
             if (line.startsWith('event:message')) {
@@ -393,7 +394,10 @@ const ChattingPage = () => {
     return historyData.records.map(record => ({
       id: generateMessageId(),
       type: record.role, // 'user' 또는 'assistant' 그대로 사용
-      content: record.content,
+      content:
+        record.role === 'assistant'
+          ? record.content.replace(/\\n/g, '  \n') // assistant 메시지의 경우 마크다운 줄바꿈으로 변환
+          : record.content, // user 메시지는 그대로
     }));
   };
 


### PR DESCRIPTION
# [FIX] 채팅 기록 렌더링 시 마크다운 줄바꿈으로 포맷 (#236)

## 📝 개요
새로운 채팅 시작 시에는 마크다운 줄바꿈이 적용되었으나, 채팅 기록 데이터를 메시지로 렌더링할 때 마크다운 줄바꿈이 적용되지 않는 것이 발견되어 수정하였습니다.

## 🔗 연관된 이슈
- closes #236

## 🔄 변경사항 및 이유
- 이스케이프 문자를 제거하여 개행문자로 인식할 수 있도록 처리 :  `\\n` -> `\n` 으로 포맷

## 📋 작업할 내용
- [x] \\n -> \n 으로 포맷

## 🔖 기타사항
백엔드 측에 띄어쓰기 제거 요청 필요
