### PR TITLE
[ENHANCEMENT] 페이지 라우팅 단위 코드 스플리팅 적용 (#181)

### DIFF
--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -11,18 +11,18 @@ import { AuthProtectedRoute } from './AuthProtectedRoute';
 import { AuthProvider } from '../providers/AuthContext';
 import MorePage from '@/pages/MyPage';
 import PostsPage from '@/pages/PostsPage';
-import CreatePostPage from '@/pages/CreatePostPage';
-import PostDetailPage from '@/pages/PostDetailPage';
-import AlarmListPage from '@/pages/AlarmListPage';
-import EditPostPage from '@/pages/EditPostPage';
-import MyPostPage from '@/pages/MyPostsPage';
 import CreateChatbotPage from '@/pages/CreateChatbotPage';
-import ChattingPage from '@/pages/ChattingPage';
-import SessionPage from '@/pages/SessionPage';
 
 const SurveyPage = React.lazy(() => import('@/pages/SurveyPage'));
 const ProblemListPage = React.lazy(() => import('@/pages/ProblemListPage'));
 const ProblemSolutionPage = React.lazy(() => import('@/pages/ProblemSolutionPage'));
+const CreatePostPage = React.lazy(() => import('@/pages/CreatePostPage'));
+const PostDetailPage = React.lazy(() => import('@/pages/PostDetailPage'));
+const AlarmListPage = React.lazy(() => import('@/pages/AlarmListPage'));
+const EditPostPage = React.lazy(() => import('@/pages/EditPostPage'));
+const MyPostPage = React.lazy(() => import('@/pages/MyPostsPage'));
+const ChattingPage = React.lazy(() => import('@/pages/ChattingPage'));
+const SessionPage = React.lazy(() => import('@/pages/SessionPage'));
 
 const Router = () => {
   return (


### PR DESCRIPTION
# [CHORE] 페이지 라우팅 단위 코드 스플리팅 적용 (#181)

## 📝 개요
- 동적 import 사용하여 일부 페이지 지연로딩을 적용하였습니다. 
- **Slow 4G 기준 12.79s -> 7.08s 약 44.6%로 개선**

## 🔗 연관된 이슈
- closes #181 

## 🔄 변경사항 및 이유

주로 순차적으로 접근되는 페이지를 기준으로 적용하였습니다.
(ex. 로그인(1차) -> 메인페이지 (2차) -> 채팅방 생성 페이지 (3차) -> 채팅 페이지 (4차 접근))

- 채팅 페이지: 로그인 -> 챗봇 생성 페이지 → 성공 시 채팅페이지 / 챗봇 채팅방 생성을 위한 정보 입력 페이지를 거쳐야만 접근 가능한 페이지
- 게시글 상세, 작성페이지 : 메인 페이지 -> 하단의 커뮤니티 버튼 클릭 → 게시글 목록 페이지에서 접근 가능. 
- 게시글 수정페이지: 메인 페이지 -> 하단의 커뮤니티 -> 게시글 상세 -> (작성자일 경우) 수정 버튼 클릭 -> 수정 페이지
- 대화 이력 페이지 : 메인페이지 -> 더보기 페이지 -> 대화 이력 페이지 / 혹은 메인 페이지 -> 채팅방 생성 페이지 -> 채팅 페이지 -> 대화 이력 페이지

## 📋 작업할 내용
- [X] 코드 스플리팅
- [X] 번들 시각화하여 청크 분리된 것 확인
- [X] LCP 측정
