### PR TITLE
[CHORE] 좋아요 낙관적 업데이트 및 서버 응답 실패 시 롤백 로직 구현 (#249)

### DIFF
--- a/src/features/post/components/LikeBoxWithActions.tsx
+++ b/src/features/post/components/LikeBoxWithActions.tsx
@@ -23,33 +23,28 @@ const LikeWithActions = ({ liked, likeCount, postId }: ILikeWithActionsProps) =>
       setLocalLike(prev => !prev);
       setLocalLikeCount(prev => prev - 1);
       try {
-        deleteLikeMutation.mutateAsync(postId);
+        await deleteLikeMutation.mutateAsync(postId);
       } catch {
-        alert('좋아요 취소 실패');
         setLocalLike(prev => !prev);
         setLocalLikeCount(prev => prev + 1);
-
-        return;
       }
     }
-
     // 좋아요 등록
-    if (!localLike) {
+    else if (!localLike) {
       setIsAnimating(true);
       setLocalLike(prev => !prev);
       setLocalLikeCount(prev => prev + 1);
       try {
         await registerLikeMutation.mutateAsync(postId);
       } catch {
-        alert('좋아요 등록 실패');
         setLocalLike(prev => !prev);
         setLocalLikeCount(prev => prev - 1);
+      } finally {
+        // 애니메이션 종료
+        setTimeout(() => {
+          setIsAnimating(false);
+        }, 300);
       }
-
-      // 애니메이션 종료
-      setTimeout(() => {
-        setIsAnimating(false);
-      }, 300);
     }
   };
 
@@ -97,6 +92,7 @@ const LikeWithActions = ({ liked, likeCount, postId }: ILikeWithActionsProps) =>
 
         {/* 좋아요 카운트 */}
         <span
+          data-testid="like-count"
           className={`
               font-medium transition-all duration-300 ease-out
               ${isAnimating ? 'scale-105' : ''}

--- a/src/features/post/components/LikeBoxWithActions.tsx
+++ b/src/features/post/components/LikeBoxWithActions.tsx
@@ -18,32 +18,38 @@ const LikeWithActions = ({ liked, likeCount, postId }: ILikeWithActionsProps) =>
   const handleLike = async () => {
     if (isAnimating) return;
 
+    // 좋아요 취소
     if (localLike && localLikeCount > 0) {
+      setLocalLike(prev => !prev);
+      setLocalLikeCount(prev => prev - 1);
       try {
         deleteLikeMutation.mutateAsync(postId);
-        setLocalLike(prev => !prev);
-        setLocalLikeCount(prev => prev - 1);
-
-        return;
       } catch {
-        return;
-      }
-    }
-    if (!localLike) {
-      try {
-        // 애니메이션 시작
-        setIsAnimating(true);
-        registerLikeMutation.mutateAsync(postId);
+        alert('좋아요 취소 실패');
         setLocalLike(prev => !prev);
         setLocalLikeCount(prev => prev + 1);
 
-        // 애니메이션 종료
-        setTimeout(() => {
-          setIsAnimating(false);
-        }, 300);
+        return;
+      }
+    }
+
+    // 좋아요 등록
+    if (!localLike) {
+      setIsAnimating(true);
+      setLocalLike(prev => !prev);
+      setLocalLikeCount(prev => prev + 1);
+      try {
+        await registerLikeMutation.mutateAsync(postId);
       } catch {
         alert('좋아요 등록 실패');
+        setLocalLike(prev => !prev);
+        setLocalLikeCount(prev => prev - 1);
       }
+
+      // 애니메이션 종료
+      setTimeout(() => {
+        setIsAnimating(false);
+      }, 300);
     }
   };
 


### PR DESCRIPTION
# [CHORE] 좋아요 낙관적 업데이트 및 롤백 로직 (#249)

## 📝 개요
좋아요 상태를 낙관적 업데이트(로컬에서 미리 상태 변경)합니다.

## 🔗 연관된 이슈
- closes #249 

## 🔄 변경사항 및 이유
- try, catch 문 내에서 await를 사용하고 있지 않았던 에러 코드 수정
- 서버 응답 전 로컬에서 미리 업데이트 하도록 수정 (낙관적 업데이트)
- 서버 응답 실패 시 롤백 로직 추가

## 📋 작업할 내용
- [x] 좋아요 추가, 삭제 코드 리팩토링
- [x] 낙관적 업데이트 변경
- [x] 로백 로직 구현
